### PR TITLE
Fix missing nm-prepare executable bits

### DIFF
--- a/build-livecd
+++ b/build-livecd
@@ -54,7 +54,7 @@ chmod +x \
   /usr/bin/discovery-setup \
   /usr/bin/find-largest-rpms \
   /usr/bin/find-missing-libs \
-  /usr/bin/get-zip-server_config
+  /usr/bin/get-zip-server_config \
   /usr/bin/nm-prepare
 %end
 KS


### PR DESCRIPTION
Looks like we're currently missing a line escape:

```
[root@fdi bin]# ls -l /usr/bin/nm-prepare
-rw-r--r-- 1 root root 719 Jan 14 12:00 /usr/bin/nm-prepare
```

```sh
Apr 07 16:49:13 fdi systemd[1161]: Failed at step EXEC spawning /usr/bin/nm-prepare: Permission denied
Apr 07 16:49:13 fdi systemd[1]: nm-prepare.service: main process exited, code=exited, status=203/EXEC
Apr 07 16:49:13 fdi systemd[1]: Unit nm-prepare.service entered failed state.
```
