### PR TITLE
Fixes #10831 - introduced fdi.zipserver command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ paths are relative to the TFTP root. So if you have two zips at
 $TFTP/zip1.zip and $TFTP/boot/zip2.zip, you would use
 `fdi.zips=zip1.zip,boot/zip2.zip`.
 
+You can force the server to download the zip files by appending
+`fdi.zipserver=<tftp-address>`, where `<tftp-address>` is the IP address of
+your TFTP server hosting the extensions.
+
 Planned features
 ----------------
 

--- a/root/usr/bin/discovery-setup
+++ b/root/usr/bin/discovery-setup
@@ -39,9 +39,12 @@ require 'discovery'
 Dir.chdir '/opt/extension'
 
 # Use a commandline option, fdi.zips=zip1.zip,zip2.zip,etc and
-# get the zips from the TFTP server
-uri = ENV['ZIP_SERVER']
+# get the zips from the TFTP server. Try zipserver passed on kernel
+# cmdline first and fall back to DHCP next-server passed in through
+# ENV
+uri = cmdline('fdi.zipserver') || ENV['ZIP_SERVER']
 zips = cmdline('fdi.zips')
+
 unless zips.nil?
   zips.split(',').each do |zip|
     begin


### PR DESCRIPTION
Adds support for fdi.zipserver= to force the server the discovery image should download the extensions from.