### PR TITLE
Do not cache initial 10 facter runs on discovered node

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -53,7 +53,7 @@ echo "TTYPath=/dev/tty1" >> /etc/systemd/journald.conf
 
 echo " * configuring foreman-proxy"
 # required foreman-proxy 1.6.3+ - http://projects.theforeman.org/issues/8006
-sed -i 's|.*:log_file:.*|:log_file: STDOUT|' /etc/foreman-proxy/settings.yml
+sed -i 's|.*:log_file:.*|:log_file: SYSLOG|' /etc/foreman-proxy/settings.yml
 # facts API is disabled by default
 echo -e "---\n:enabled: true" > /etc/foreman-proxy/settings.d/facts.yml
 /sbin/usermod -a -G tty foreman-proxy

--- a/root/usr/bin/discovery-register
+++ b/root/usr/bin/discovery-register
@@ -84,9 +84,15 @@ facts = Hash[Facter.to_hash.select {|k,v| k =~ /address|hardware|manufacturer|pr
 facts.keys.sort.each {|k| log_msg " #{k}: #{facts[k]}"}
 
 # loop, but only upload on changes
+i = cmdline("fdi.cachefacts", 10).to_i
 while true do
   uninteresting_facts=/kernel|operatingsystem|osfamily|ruby|path|time|swap|free|filesystem|version|selinux/i
   facts = Facter.to_hash.reject! {|k,v| k =~ uninteresting_facts }
+  if i > 0
+    # clear cache because during bootproces facts may change
+    Facter.clear
+    i -= 1
+  end
   unless YAML.load(read_cache) == facts
     log_msg "Fact cache invalid, reloading to foreman"
     write_cache(YAML.dump(facts)) if upload


### PR DESCRIPTION
start discovery-register service after network-online
because interfaces have to be renamed before starting the service.

because facter caches the facts it would otherwise hold the initial interface names (ethx). And the service keeps sending these (wrong) interface names. 

This causes foreman to be unable to discover the host with (Debug) message: "Unable to assign subnet, primary interface is missing IP address"