### PR TITLE
Fixes #12007 - status screen fixed for kexec workflow

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
@@ -36,7 +36,7 @@ def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_
     end
     if dhcp
       if perform_upload(proxy_url, proxy_type, new_custom_facts(mac))
-        [:screen_status, generate_info(' - awaiting kexec into installer')]
+        [:screen_status, generate_info(' - awaiting kexec into installer', proxy_url, proxy_type)]
       else
         :screen_welcome
       end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/status.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/status.rb
@@ -1,4 +1,4 @@
-def generate_info extra_status = ''
+def generate_info extra_status = '', server = discover_server, proxy_type = proxy_type
   status = "N/A (use Status to update)"
   response = "N/A"
   if File.exist?(f = '/tmp/discovery-http-success')


### PR DESCRIPTION
It was not set to server when PXE-less was used (kernel command line is empty
in this case).