### PR TITLE
Refs #12003 - legacy Facts API no longer required

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -78,11 +78,6 @@ cat >/etc/foreman-proxy/settings.d/discovery_image.yml <<'CFG'
 :enabled: true
 CFG
 
-cat >/etc/foreman-proxy/settings.d/facts.yml <<'CFG'
----
-:enabled: true
-CFG
-
 cat >/etc/foreman-proxy/settings.d/bmc.yml <<'CFG'
 ---
 :enabled: true


### PR DESCRIPTION
@stbenjam This is the last series of patches. Since fdi 3.0+ now listens on
HTTPS by default, we no longer can leverage the standard Smart Proxy Facts API
which requires SSL client auth.

This series (plugin, image, proxy-proxy, proxy-image) adds new API which I
named "inventory_api" not to confuse with original "facts_api".

This is the last one, related:

https://github.com/theforeman/smart_proxy_discovery/pull/9
https://github.com/theforeman/foreman_discovery/pull/223
https://github.com/theforeman/smart_proxy_discovery_image/pull/3

Many thanks for your effort!