### PR TITLE
Fixes #12322 - disabled resend button for PXE-less

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/network.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/network.rb
@@ -30,7 +30,7 @@ def screen_network mac, ip = cmdline('fdi.pxip', ''), gw = cmdline('fdi.pxgw', '
       return [:screen_network, mac, ip, gw, dns]
     end
     action = Proc.new { configure_network true, mac, ip, gw, dns }
-    [:screen_info, action, "Configuring network via DHCP. This operation can take several minutes to complete.", "Unable to bring network via DHCP",
+    [:screen_info, action, "Configuring network. This operation can take several minutes to complete.", "Unable to bring up network",
       [:screen_foreman, mac, gw],
       [:screen_network, mac, ip, gw, dns]]
   else

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/status.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/status.rb
@@ -68,8 +68,12 @@ def screen_status status = generate_info, active_button = 0
   elsif answer == b_ssh
     :screen_ssh
   elsif answer == b_resend
-    command("rm -f /tmp/discovery-http*")
-    command("systemctl reload discovery-register")
+    if cmdline('BOOTIF')
+      command("rm -f /tmp/discovery-http*")
+      command("systemctl reload discovery-register")
+    else
+      Newt::Screen.win_message("Not supported", "OK", "Resending not possible in PXE-less, reboot and start over.")
+    end
     :screen_status
   else
     :quit


### PR DESCRIPTION
Resend button restarts discovery-register service, but in PXE-less environment
this service is inactive. For technical reasons, we just emit message for user
to start over.