### PR TITLE
Fixes #12323 - def number of register calls is zero

### DIFF
--- a/root/usr/bin/discovery-register
+++ b/root/usr/bin/discovery-register
@@ -63,7 +63,7 @@ facts = Hash[Facter.to_hash.select {|k,v| k =~ /address|hardware|manufacturer|pr
 facts.keys.sort.each {|k| log_msg " #{k}: #{facts[k]}"}
 
 # loop, but only upload on changes
-i = cmdline("fdi.cachefacts", 5).to_i rescue 5
+i = cmdline("fdi.cachefacts", 0).to_i rescue 0
 upload_sleep = cmdline("fdi.uploadsleep", 30).to_i rescue 30
 while true do
   uninteresting_facts=/kernel|operatingsystem|osfamily|ruby|path|time|swap|free|filesystem|version|selinux/i

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/countdown.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/countdown.rb
@@ -22,7 +22,7 @@ EOT
   f.add(t, l_press)
   f.draw
   key_was_pressed = false
-  sec = 10
+  sec = cmdline("fdi.countdown", 15).to_i rescue 15
   while sec > 0
     l_press.set_text("< Press any key (#{sec}s) >")
     sec = sec - 1


### PR DESCRIPTION
If network is down (typical problem on slower DHCP networks) during initial discovery, we should still allow users to override this value. But it should not be 5 by default to prevent race conditions described above.