### PR TITLE
Fixes #12275 - fixed error messages and NIC sort

### DIFF
--- a/root/usr/bin/generate-proxy-cert
+++ b/root/usr/bin/generate-proxy-cert
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+# When booted from ISO, foreman-proxy starts up by default but since
+# network is not yet configured, we cannot continue. This makes
+# the service to fail.
+[ -f /etc/NetworkManager/system-connections/primary ] || exit 1
+
 source /usr/share/fdi/commonfunc.sh
 exportKCL
 
 DIR=/etc/foreman-proxy
 DAYS=${KCL_FDI_PROXY_CERT_DAYS:-999}
-IP=$(nmcli -t -f IP4.ADDRESS con show primary | cut -f2 -d: | cut -f1 -d/)
+IP=$(nmcli -t -f IP4.ADDRESS con show primary 2>/dev/null | cut -f2 -d: | cut -f1 -d/)
 
 openssl req -x509 \
   -newkey rsa:2048 \


### PR DESCRIPTION
Here is one more @stbenjam. Unfortunately my last patch `.sort` broke master,
forgot to add `.each`. This fixes it and also improves our logging and error
states. Also STDOUT is silenced for facter as there is no other way to tell
facter not to raise errors when no IP is present on the system.