### PR TITLE
WIP - Fixes #12389 - added image-deployment service

### DIFF
--- a/00-repos-centos7.ks
+++ b/00-repos-centos7.ks
@@ -3,3 +3,4 @@ repo --name=centos-updates --mirrorlist=http://mirrorlist.centos.org/?release=7&
 repo --name=epel7 --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
 repo --name=foreman-el7 --baseurl=http://yum.theforeman.org/nightly/el7/$basearch/
 repo --name=foreman-plugins-el7 --baseurl=http://yum.theforeman.org/plugins/nightly/el7/$basearch/
+repo --name=wip-epel7-udpcast --baseurl=https://copr-be.cloud.fedoraproject.org/results/lzap/udp-cast-epel7/epel-7-$basearch/

--- a/20-packages.ks
+++ b/20-packages.ks
@@ -66,6 +66,11 @@ grub2-efi
 efibootmgr
 shim
 
+# Device writing
+nmap-ncat
+lzop
+udpcast
+
 #
 # Packages to Remove
 #

--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -126,4 +126,18 @@ echo "alias 'yum=echo DO NOT USE YUM; yum'" >> /root/.bashrc
 # Base env for extracting zip extensions
 mkdir -p /opt/extension/{bin,lib,lib/ruby,facts}
 
+# Device writer for image-based deployment
+mkdir -p /etc/devicewriter/
+PORT=13000
+for pre in sd hd vd; do
+	for x in {a..z}; do
+		echo "DWPORT=$PORT" > /etc/devicewriter/$pre$x.conf
+		((PORT+=1))
+	done
+	((PORT+=74))
+done
+cat > /etc/udev/rules.d/99-devicewriter.rules <<'UDEV'
+ACTION=="add", SUBSYSTEM=="block", NAME!="loop[0-9]*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="devicewriter@$name.service"
+UDEV
+
 %end

--- a/aux/devicemap.sh
+++ b/aux/devicemap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Prints mapping table of block devices and TCP ports
+#
+PORT=13000
+echo "dev | port"
+echo "----|------"
+for pre in sd hd vd; do
+  for x in {a..z}; do
+    echo "$pre$x | $PORT"
+    ((PORT+=1))
+  done
+  ((PORT+=74))
+done

--- a/root/etc/rc.d/rc.local
+++ b/root/etc/rc.d/rc.local
@@ -5,10 +5,21 @@ exportKCL
 
 # setup root password
 if [[ ! -z "$KCL_FDI_ROOTPW" ]]; then
-  echo "root:$KCL_FDI_ROOTPW" | chpasswd >/dev/null
+	echo "root:$KCL_FDI_ROOTPW" | chpasswd >/dev/null
 fi
 
 # enable ssh
 if [ "$KCL_FDI_SSH" == "1" ]; then
-  systemctl start sshd
+	systemctl start sshd
+fi
+
+if [ "$KCL_FDI_EXPOSEBDEV" == "1" ]; then
+	firewall-cmd --zone=public \
+		--add-port=13000-13025/tcp \
+		--add-port=13100-13125/tcp \
+		--add-port=13200-13225/tcp
+fi
+
+if [[ ! -z "$KCL_FDI_UDPCAST" ]]; then
+	systemctl start udp-receiver@${KCL_FDI_UDPCAST}.service
 fi

--- a/root/etc/systemd/system/devicewriter@.service
+++ b/root/etc/systemd/system/devicewriter@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Device writer service for /dev/%I
+ConditionPathExists=/dev/%I
+ConditionPathExists=/etc/devicewriter/%I.conf
+
+[Service]
+EnvironmentFile=-/etc/devicewriter/%I.conf
+ExecStart=/usr/bin/bash -c "nc -l ${DWPORT} | lzop -d | cat > /dev/%I"
+Restart=always

--- a/root/etc/systemd/system/udp-receiver@.service
+++ b/root/etc/systemd/system/udp-receiver@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=UDPcast device writer service for /dev/%I
+ConditionPathExists=/dev/%I
+
+[Service]
+ExecStartPre=/usr/bin/firewall-cmd --zone=public --add-port=9000-9100/udp
+ExecStart=/usr/sbin/udp-receiver --file /dev/%I --nokbd
+Restart=always


### PR DESCRIPTION
Image-based deployment via discovery

_Option A: stream-based_

This adds a service template that starts netcat for each block device
(excluding loops) on particular fixed port. This allows anyone to write to
block devices remotely effectively doing image deployment. The service only
allows writing, not reading, therefore this should be secure. But by default,
the ports are blocked by firewall and `fdi.exposebdev` must be set to `1` in
order to have the devices exposed.

Typical usage:

```
virt-builder fedora-22 --output /tmp/f22.img --size 123450b
```

Where 123450 is full size of the block device (do not forget `b` suffix) as
reported by facter. Image can be smaller (and FS expanded later on) of course.

```
cat /tmp/f22.img | lzop | ncat 192.168.122.68 13200
```

Lzop compressor is a must, the endpoint expect stream to be compressed with lzop.
Port 13200 is the port for `/dev/vda` since in my case this was a VM created with KVM. 
See the mapping table below.

_Option B: UDP cast - unicast or multicast_

This uses https://en.wikipedia.org/wiki/UDPCast utility that is in EPEL (actually the package is pending in testing repo: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2015-ef035e942f). Read the project page how it works or watch our Community demo from 10.12.2015.

Usage is simple, enable this service by providing device name without `/dev/` prefix with this kernel option: `fdi.udpcast=vda`. The boot as many discovered hosts as you want and once you are ready to send the image do:

```
udp-sender /tmp/cirros.img --interface virbr0
```

I need to specify the device as I use libvirt virtual network. Make sure your network allows multicast UDP packets. When using just one host, udpcast uses unicast.

The port mapping for option A is:

| dev | port |
| --- | --- |
| sda | 13000 |
| sdb | 13001 |
| sdc | 13002 |
| sdd | 13003 |
| sde | 13004 |
| sdf | 13005 |
| sdg | 13006 |
| sdh | 13007 |
| sdi | 13008 |
| sdj | 13009 |
| sdk | 13010 |
| sdl | 13011 |
| sdm | 13012 |
| sdn | 13013 |
| sdo | 13014 |
| sdp | 13015 |
| sdq | 13016 |
| sdr | 13017 |
| sds | 13018 |
| sdt | 13019 |
| sdu | 13020 |
| sdv | 13021 |
| sdw | 13022 |
| sdx | 13023 |
| sdy | 13024 |
| sdz | 13025 |
| hda | 13100 |
| hdb | 13101 |
| hdc | 13102 |
| hdd | 13103 |
| hde | 13104 |
| hdf | 13105 |
| hdg | 13106 |
| hdh | 13107 |
| hdi | 13108 |
| hdj | 13109 |
| hdk | 13110 |
| hdl | 13111 |
| hdm | 13112 |
| hdn | 13113 |
| hdo | 13114 |
| hdp | 13115 |
| hdq | 13116 |
| hdr | 13117 |
| hds | 13118 |
| hdt | 13119 |
| hdu | 13120 |
| hdv | 13121 |
| hdw | 13122 |
| hdx | 13123 |
| hdy | 13124 |
| hdz | 13125 |
| vda | 13200 |
| vdb | 13201 |
| vdc | 13202 |
| vdd | 13203 |
| vde | 13204 |
| vdf | 13205 |
| vdg | 13206 |
| vdh | 13207 |
| vdi | 13208 |
| vdj | 13209 |
| vdk | 13210 |
| vdl | 13211 |
| vdm | 13212 |
| vdn | 13213 |
| vdo | 13214 |
| vdp | 13215 |
| vdq | 13216 |
| vdr | 13217 |
| vds | 13218 |
| vdt | 13219 |
| vdu | 13220 |
| vdv | 13221 |
| vdw | 13222 |
| vdx | 13223 |
| vdy | 13224 |
| vdz | 13225 |
