### PR TITLE
Fixes #12420 - primary detected correctly for PXE-less

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery.rb
@@ -68,6 +68,23 @@ def cmdline option=nil, default=nil
   end
 end
 
+def detect_first_nic_with_link
+  log_debug "Detecting the first NICs with link"
+  mac = ''
+  Dir.glob('/sys/class/net/*').sort.each do |ifn|
+    name = File.basename ifn
+    next if name == "lo"
+    mac = File.read("#{ifn}/address").chomp rescue ''
+    link = File.read("#{ifn}/carrier").chomp == "1" rescue false
+    if link
+      log_debug "Interface with link found: #{mac} (#{name})"
+      break
+    end
+  end
+  log_debug "No interfaces with link found, using #{mac}"
+  mac
+end
+
 def normalize_mac mac
   mac.split('-')[1..6].join(':') rescue nil
 end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -117,22 +117,6 @@ def cleanup
   Newt::Screen.finish
 end
 
-def detect_first_nic_with_link
-  log_debug "Trying to guess the first NICs with link, fdi.pxmac was NOT provided"
-  mac = nil
-  Dir.glob('/sys/class/net/*').sort.each do |ifn|
-    name = File.basename ifn
-    next if name == "lo"
-    mac = File.read("#{ifn}/address").chomp rescue "??:??:??:??:??:??"
-    link = File.read("#{ifn}/carrier").chomp == "1" rescue false
-    if link
-      log_debug "Interface with link found: #{name}=#{mac}"
-      break
-    end
-  end
-  mac
-end
-
 log_msg "Kernel opts: #{cmdline}"
 
 def main_loop

--- a/root/usr/share/fdi/facts/discovery-facts.rb
+++ b/root/usr/share/fdi/facts/discovery-facts.rb
@@ -32,7 +32,7 @@ end
 
 def discovery_bootif
   # PXELinux dash-separated hexadecimal *without* the leading hardware type
-  cmdline('BOOTIF', Facter.fact("macaddress").value).gsub(/^[a-fA-F0-9]+-/, '').gsub('-', ':') rescue '00:00:00:00:00:00'
+  cmdline('BOOTIF', cmdline('fdi.pxmac', detect_first_nic_with_link)).gsub(/^[a-fA-F0-9]+-/, '').gsub('-', ':') rescue '00:00:00:00:00:00'
 end
 
 Facter.add("discovery_version") do


### PR DESCRIPTION
The root cause is our discovery_bootif fact which only accepts BOOTIF option,
but we should also use fdi.pxmac when BOOTIF is not present. Also added one
more fallback if none present - tries to detect first IFACE with link. And if
that fails, we fallback to facter's "macaddress" which is pretty less "random"
and generally a bad choice.