### PR TITLE
Fixes #12430 - unattended mode sends custom facts now

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -171,15 +171,17 @@ def main_loop
           status = configure_network false, mac
         end
         log_debug "Unattended network configuration finished, result: #{status}"
-        log_debug "Unattended facts collection started"
         facts = new_custom_facts(mac)
-        [1..9].each do |n|
+        (1..99).each do |n|
           if (fact_name = cmdline("fdi.pxfactname#{n}"))
             fact_value = cmdline("fdi.pxfactvalue#{n}")
+            log_debug "Adding custom fact #{fact_name}=#{fact_value}"
             facts[fact_name] = fact_value
+          else
+            log_debug "Fact named fdi.pxfactname#{n} not present, so this was the last one"
+            break
           end
         end
-        log_debug "Unattended facts collection finished"
         log_debug "Unattended facts upload started"
         result = upload(proxy_url, proxy_type, facts)
         log_debug "Unattended facts upload finished, result: #{result}"


### PR DESCRIPTION
Sachin @sghai found an issue when using unattended, the custom facts are *not*
sent at all. Mistyped parenthesis there. Thanks @stbenjam!