### PR TITLE
Fixes #12429 - fixed network race conditions

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -48,7 +48,10 @@ systemctl disable ipmi.service
 echo " * open foreman-proxy port via firewalld"
 firewall-offline-cmd --zone=public --add-port=8443/tcp --add-port=8448/tcp
 
-echo " * setting up foreman proxy"
+echo " * setting up foreman proxy service"
+sed -i 's/After=.*/After=basic.target network-online.target nm-prepare.service/' /usr/lib/systemd/system/foreman-proxy.service
+sed -i 's/Wants=.*/Wants=basic.target network-online.target nm-prepare.service/' /usr/lib/systemd/system/foreman-proxy.service
+sed -i '/\[Unit\]/a ConditionPathExists=/etc/NetworkManager/system-connections/primary' /usr/lib/systemd/system/foreman-proxy.service
 sed -i '/\[Service\]/a EnvironmentFile=-/etc/default/discovery' /usr/lib/systemd/system/foreman-proxy.service
 sed -i '/\[Service\]/a ExecStartPre=/usr/bin/generate-proxy-cert' /usr/lib/systemd/system/foreman-proxy.service
 sed -i '/\[Service\]/a PermissionsStartOnly=true' /usr/lib/systemd/system/foreman-proxy.service

--- a/root/etc/systemd/system/discovery-fetch-extensions.service
+++ b/root/etc/systemd/system/discovery-fetch-extensions.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Download zip extensions to this image
-Wants=discovery-start-extensions.service
+Wants=network-online.target discovery-start-extensions.service
 Before=discovery-start-extensions.service
+After=network-online.target
 
 [Service]
 Type=oneshot

--- a/root/etc/systemd/system/discovery-menu.service
+++ b/root/etc/systemd/system/discovery-menu.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Display interactive TUI on tty1
 Wants=basic.target
-After=basic.target network.target network-online.target nss-lookup.target
+After=basic.target network.target nss-lookup.target
 ConditionPathExists=/dev/tty1
 
 [Service]

--- a/root/etc/systemd/system/discovery-register.service
+++ b/root/etc/systemd/system/discovery-register.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Register this host in Foreman
-After=basic.target network.target network-online.target nss-lookup.target foreman-proxy.service discovery-register.service
+Wants=network-online.target
+After=basic.target network-online.target nss-lookup.target foreman-proxy.service
 
 [Service]
 Type=simple

--- a/root/etc/systemd/system/nm-prepare.service
+++ b/root/etc/systemd/system/nm-prepare.service
@@ -2,6 +2,7 @@
 Description=Prepares NetworkManager configuration for primary interface
 Wants=basic.target
 Before=NetworkManager.service
+ConditionKernelCommandLine=BOOTIF
 
 [Service]
 Type=oneshot

--- a/root/usr/bin/generate-proxy-cert
+++ b/root/usr/bin/generate-proxy-cert
@@ -3,7 +3,7 @@
 # When booted from ISO, foreman-proxy starts up by default but since
 # network is not yet configured, we cannot continue. This makes
 # the service to fail.
-[ -f /etc/NetworkManager/system-connections/primary ] || exit 1
+[ -f /etc/NetworkManager/system-connections/primary ] || exit 101
 
 source /usr/share/fdi/commonfunc.sh
 exportKCL

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -84,6 +84,7 @@ def configure_network static, mac, ip=nil, gw=nil, dns=nil
   command("nmcli connection reload")
   command("nmcli connection down primary")
   result = command("nmcli connection up primary", false)
+  command("nm-online -s -q --timeout=45") unless static
   # restarting proxy with regenerated SSL self-signed cert
   command("systemctl start foreman-proxy") if result
   result


### PR DESCRIPTION
This patch replaces
https://github.com/theforeman/foreman-discovery-image/pull/48

Makes sure foreman-proxy starts after network-online. Also fixes other possible
related race conditions. Comments inline.