### PR TITLE
Remove deprecated nobase ks option

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -1,4 +1,4 @@
-%packages --excludedocs --nobase
+%packages --excludedocs
 bash
 kernel
 grub2


### PR DESCRIPTION
This was removed from pykickstart library in Fedora 23, so the process is
failing on this distro. It has no effect in RHEL7+ and Fedora 18+ nowdays.

@stbenjam quick merge please? It's tested.