### PR TITLE
RHBZ#1285810 - RHEL/CentOS 7.2 dracut dependency fixed

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -15,6 +15,13 @@ tftp
 lldpad
 isomd5sum
 
+# Dracut (https://bugzilla.redhat.com/show_bug.cgi?id=1285810)
+dracut
+tar
+gzip
+dd
+bash
+
 # Facter
 facter
 ethtool


### PR DESCRIPTION
Due to missing dependency in dracut package, the image fails to build with RHEL
7.2 base. This prevents from missing the dependency.

Symptoms: Init ram disk is missing from the ISO file.