### PR TITLE
RHBZ#1285810 - RHEL/CentOS 7.2 dracut dependency fixed (dd)

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -19,7 +19,7 @@ isomd5sum
 dracut
 tar
 gzip
-dd
+coreutils
 bash
 
 # Facter


### PR DESCRIPTION
I need one additional change, it builds upstream but brew does not support
provides perhaps, the correct package name is "coreutils" really.