### PR TITLE
RHBZ#1285810 - RHEL/CentOS 7.2 dracut dependency fixed (tar)

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -15,12 +15,9 @@ tftp
 lldpad
 isomd5sum
 
-# Dracut (https://bugzilla.redhat.com/show_bug.cgi?id=1285810)
-dracut
+# Dracut missing deps (https://bugzilla.redhat.com/show_bug.cgi?id=1285810)
 tar
 gzip
-coreutils
-bash
 
 # Facter
 facter
@@ -75,7 +72,6 @@ shim
 -prelink
 -setserial
 -ed
--tar
 -authconfig
 -wireless-tools
 


### PR DESCRIPTION
@stbenjam shame on me, this was always working upstream because we do not yet
build against CentOS 7.2 but downstream this was a problem. This is now the
final fix.