### PR TITLE
Fixes #12641 - Refresh facts errors and adds new entry mac000000000000

### DIFF
--- a/root/usr/share/fdi/facts/discovery-facts.rb
+++ b/root/usr/share/fdi/facts/discovery-facts.rb
@@ -19,7 +19,7 @@
 # also available at http://www.gnu.org/copyleft/gpl.html.
 
 require 'facter/util/ip'
-require 'discovery'
+require '/usr/lib64/ruby/vendor_ruby/discovery.rb'
 
 def cmdline option=nil, default=nil
   line = File.open("/proc/cmdline", 'r') { |f| f.read }
@@ -48,13 +48,13 @@ Facter.add("discovery_release") do
   end
 end
 
-Facter.add("discovery_bootif") do
+Facter.add("discovery_bootif", :timeout => 10) do
   setcode do
     discovery_bootif
   end
 end
 
-Facter.add("discovery_bootip") do
+Facter.add("discovery_bootip", :timeout => 10) do
   setcode do
     result = Facter.fact("ipaddress").value
     required = discovery_bootif
@@ -95,7 +95,7 @@ Facter::Util::IP.get_interfaces.each do |interface|
       Facter.debug("Running ethtool on #{interface} didn't give any information")
     end
     attributes.each do |fact, value|
-      Facter.add("#{fact}_#{Facter::Util::IP.alphafy(interface)}") do
+      Facter.add("#{fact}_#{Facter::Util::IP.alphafy(interface)}", :timeout => 10) do
         confine :kernel => "Linux"
         setcode do
           value


### PR DESCRIPTION
47d3d43da11e introduced fallback via detect_first_nic_with_link method, but
since this was called within Proxy context, SYSLOG was raising an exception
"already opened socket". Therefore we need to detect the context in `log_`
methods and log via native Proxy logging library instead.

This patch fixes this problem and also improves logging and detection code.