### PR TITLE
Fixes #12675 - custom fact screen shows up in PXE-less with DHCP

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
@@ -1,4 +1,4 @@
-def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_type = cmdline('proxy.type'), dhcp = false
+def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_type = cmdline('proxy.type')
   Newt::Screen.centered_window(59, 20, "Foreman credentials")
   f = Newt::Form.new
   t_desc = Newt::Textbox.new(2, 2, 54, 6, Newt::FLAG_WRAP)
@@ -34,15 +34,7 @@ def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_
       Newt::Screen.win_message("Invalid URL", "OK", "Not a valid Foreman URL: #{url} (#{e})")
       return [:screen_foreman, mac, gw, url, proxy_type]
     end
-    if dhcp
-      if perform_upload(proxy_url, proxy_type, new_custom_facts(mac))
-        [:screen_status, generate_info(' - awaiting kexec into installer', proxy_url, proxy_type)]
-      else
-        :screen_welcome
-      end
-    else
-      [:screen_facts, mac, proxy_url, proxy_type]
-    end
+    [:screen_facts, mac, proxy_url, proxy_type]
   else
     :screen_welcome
   end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
@@ -50,7 +50,7 @@ def screen_primary_iface dhcp = false
     if dhcp
       action = Proc.new { configure_network false, primary_mac }
       [:screen_info, action, "Configuring network via DHCP. This operation can take several minutes to complete.", "Unable to bring network via DHCP",
-        [:screen_foreman, primary_mac, nil, cmdline('proxy.url'), cmdline('proxy.type'), true],
+        [:screen_foreman, primary_mac, nil, cmdline('proxy.url'), cmdline('proxy.type')],
         [:screen_network, primary_mac]]
     else
       detect_ip, detect_gw, detect_dns = detect_ipv4_credentials('primary')


### PR DESCRIPTION
It was no showing up, for some reason, I simply sent the facts without custom
ones.

Can you take a look please @stbenjam? This one and
https://github.com/theforeman/foreman-discovery-image/pull/58