### PR TITLE
when building image on CentOS, option log_file: STDOUT  conflicts wit…

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -36,7 +36,7 @@ echo "TTYPath=/dev/tty1" >> /etc/systemd/journald.conf
 
 echo " * configuring foreman-proxy"
 # required foreman-proxy 1.6.3+ - http://projects.theforeman.org/issues/8006
-sed -i 's|.*:log_file:.*|:log_file: STDOUT|' /etc/foreman-proxy/settings.yml
+sed -i 's|.*:log_file:.*|#:log_file: STDOUT|' /etc/foreman-proxy/settings.yml
 # facts API is disabled by default
 echo -e "---\n:enabled: true" > /etc/foreman-proxy/settings.d/facts.yml
 /sbin/usermod -a -G tty foreman-proxy


### PR DESCRIPTION
when building image on CentOS, option log_file: STDOUT  conflicts with option daemon: true.