### PR TITLE
Fixes #8540 - hostname is no longer sent in DHCP request

### DIFF
--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -57,6 +57,7 @@ autoconnect-priority=1
 mac-address=$mac
 [ipv4]
 method=auto
+dhcp-send-hostname=false
 dhcp-timeout=$timeout
 [ipv6]
 method=ignore
@@ -80,6 +81,7 @@ dhcp-timeout=$timeout
 ignore-auto-dns=true
 ignore-auto-routes=true
 never-default=true
+dhcp-send-hostname=false
 [ipv6]
 method=ignore
 EONS


### PR DESCRIPTION
We currently send "fdi" hostname in a DHCP request. This can create secondary
lease when PXE DHCP lease was sent with a different name (which is likely).
This saves one extra lease in case BIOS/EFI also sends without any hostname
which is the case for most of them.

To test this: Boot a host without this patch, you should see "fdi" in the
leases file. Reboot with a different IP address and this patch, no hostname
should be sent.