### PR TITLE
Fixes #7821 - start and enable lldpad on all net interfaces

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -126,4 +126,10 @@ echo "alias 'yum=echo DO NOT USE YUM; yum'" >> /root/.bashrc
 # Base env for extracting zip extensions
 mkdir -p /opt/extension/{bin,lib,lib/ruby,facts}
 
+echo " * setting up lldp service"
+systemctl enable lldpad.service
+cat > /etc/udev/rules.d/82-enable-lldp.rules <<'UDEV'
+ACTION=="add", SUBSYSTEM=="net", NAME!="lo", RUN+="/usr/bin/enable-lldp"
+UDEV
+
 %end

--- a/README.md
+++ b/README.md
@@ -219,3 +219,11 @@ issue)[http://projects.theforeman.org/projects/discovery/issues/new] and
 select "Image" Category.
 
 vim:tw=75
+
+License
+-------
+
+The kickstart file, utility scripts and other software in this repo is licensed under GNU GPL v2 or later. Exceptions are individually commented in file headers.
+
+Generated image is covered by additional licenses, refer to Fedora and CentOS licensing information.
+

--- a/root/usr/bin/enable-lldp
+++ b/root/usr/bin/enable-lldp
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+enable_lldp_int() {
+  local int=$1
+  shift
+  local ip=$1
+  shift
+
+  variables="$@"
+
+  lldptool -L -i $int adminstatus=rxtx
+
+  for var in $variables; do
+    lldptool -i $int -T -V $var enableTx=yes
+  done
+
+}
+
+for inter in $(ls /sys/class/net/ | grep -v "lo"); do
+ enable_lldp_int $inter $ipaddress portDesc sysName sysDesc sysCap
+done
+
+exit 0

--- a/root/usr/share/fdi/facts/openlldp.rb
+++ b/root/usr/share/fdi/facts/openlldp.rb
@@ -1,0 +1,116 @@
+# grabbed from:
+# https://raw.githubusercontent.com/razorsedge/puppet-openlldp/master/lib/facter/openlldp.rb
+
+#Copyright (C) 2012 Mike Arnold <mike@razorsedge.org>
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+# Fact:
+#   lldp_neighbor_chassisid_<interface>
+#   lldp_neighbor_mngaddr_ipv4_<interface>
+#   lldp_neighbor_mngaddr_ipv6_<interface>
+#   lldp_neighbor_mtu_<interface>
+#   lldp_neighbor_portid_<interface>
+#   lldp_neighbor_sysname_<interface>
+#   lldp_neighbor_pvid_<interface>
+#
+# Purpose:
+#   Return information about the host's LLDP neighbors.
+#
+# Resolution:
+#   On hosts with the lldptool binary, send queries to the lldpad for each of
+#   the host's Ethernet interfaces and parse the output.
+#
+# Caveats:
+#   Assumes that the connected Ethernet switch is sending LLDPDUs, Open-LLDP
+#   (lldpad) is running, and lldpad is configured to receive LLDPDUs on each
+#   Ethernet interface.
+#
+# Authors:
+#   Mike Arnold <mike@razorsedge.org>
+#
+# Copyright:
+#   Copyright (C) 2012 Mike Arnold, unless otherwise noted.
+#
+
+require 'facter/util/macaddress'
+
+# http://www.ruby-forum.com/topic/3418285#1040695
+module Enumerable
+  def grep_v(cond)
+    select {|x| not cond === x}
+  end
+end
+
+#if Facter::Util::Resolution.which('lldptool')
+if File.exists?('/usr/sbin/lldptool')
+  lldp = {
+    # LLDP Name    Numeric value
+    'chassisID'    => '1',
+    'portID'       => '2',
+    'sysName'      => '5',
+    'mngAddr_ipv4' => '8',
+    'mngAddr_ipv6' => '8',
+    'PVID'         => '0x0080c201',
+    'MTU'          => '0x00120f04',
+  }
+
+  # Remove interfaces that pollute the list (like lo and bond0).
+  Facter.value('interfaces').split(/,/).grep_v(/^lo$|^bond[0-9]/).each do |interface|
+    # Loop through the list of LLDP TLVs that we want to present as facts.
+    lldp.each_pair do |key, value|
+      Facter.add("lldp_neighbor_#{key}_#{interface}") do
+        setcode do
+          result = ""
+          output = Facter::Util::Resolution.exec("lldptool get-tlv -n -i #{interface} -V #{value} 2>/dev/null")
+          if not output.nil?
+            case key
+            when 'sysName', 'MTU'
+              output.split("\n").each do |line|
+                result = $1 if line.match(/^\s+(.*)/)
+              end
+            when 'chassisID'
+              output.split("\n").each do |line|
+                ether = $1 if line.match(/MAC:\s+(.*)/)
+                result = Facter::Util::Macaddress.standardize(ether)
+              end
+            when 'portID'
+              output.split("\n").each do |line|
+                result = $1 if line.match(/(?:Ifname|Local):\s+(.*)/)
+              end
+            when 'mngAddr_ipv4'
+              output.split("\n").each do |line|
+                result = $1 if line.match(/IPv4:\s+(.*)/)
+              end
+            when 'mngAddr_ipv6'
+              output.split("\n").each do |line|
+                result = $1 if line.match(/IPv6:\s+(.*)/)
+              end
+            when 'PVID'
+              output.split("\n").each do |line|
+                result = $1.to_i if line.match(/(?:Info|PVID):\s+(.*)/)
+              end
+            else
+              # case default
+              result = nil
+            end
+          else
+            # No output from lldptool
+            result = nil
+          end
+          result
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change enables the lldpad daemon, turns on lldp for
all interfaces (excluding lo) and then uses the openlldp.rb
written by razorsedge to report the lldp data in facter

messed up the old PR so I'm cutting another one. 

It's been months since I've had a working foreman-discover-image test env. so this is untested.