### PR TITLE
Fixes #14247 - prevents proxy from timing out during startup

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -95,8 +95,6 @@ cat >/etc/foreman-proxy/settings.d/logs.yml <<'CFG'
 CFG
 
 echo " * setting up systemd"
-echo "DefaultTimeoutStartSec=30s" >> /etc/systemd/system.conf
-echo "DefaultTimeoutStopSec=5s" >> /etc/systemd/system.conf
 echo "DumpCore=no" >> /etc/systemd/system.conf
 
 echo " * setting multi-user.target as default"


### PR DESCRIPTION
Setting 30 secs looked like a sane value to me, but it's indeed longer than DNS query timeout which can happen on systems with incorrect DNS setup.