### PR TITLE
Fixes #14315 - fixed proxy logger and enabled log buffer

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -69,6 +69,8 @@ cat >/etc/foreman-proxy/settings.yml <<'CFG'
 :https_port: 8443
 :log_file: SYSLOG
 :log_level: DEBUG
+:log_buffer: 1000
+:log_buffer_errors: 500
 CFG
 
 cat >/etc/foreman-proxy/settings.d/discovery_image.yml <<'CFG'
@@ -83,6 +85,11 @@ cat >/etc/foreman-proxy/settings.d/bmc.yml <<'CFG'
 CFG
 
 cat >/etc/foreman-proxy/settings.d/facts.yml <<'CFG'
+---
+:enabled: true
+CFG
+
+cat >/etc/foreman-proxy/settings.d/logs.yml <<'CFG'
 ---
 :enabled: true
 CFG

--- a/root/usr/lib64/ruby/vendor_ruby/discovery.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery.rb
@@ -31,8 +31,9 @@ require 'yaml'
 require 'json'
 
 def log_msg msg
-  if defined? ::Proxy::Log
-    ::Proxy::Log.logger.info msg
+  if defined? ::Proxy::LoggerFactory
+    # helper methods are also used from proxy context (refresh facts -> facter API -> custom facts)
+    ::Proxy::LoggerFactory.logger.info msg
   else
     Syslog.open($0, Syslog::LOG_PID | Syslog::LOG_CONS) { |s| s.info msg.to_s.gsub('%', '%%') rescue false }
   end
@@ -41,8 +42,9 @@ rescue Exception => e
 end
 
 def log_err msg
-  if defined? ::Proxy::Log
-    ::Proxy::Log.logger.error msg
+  if defined? ::Proxy::LoggerFactory
+    # helper methods are also used from proxy context (refresh facts -> facter API -> custom facts)
+    ::Proxy::LoggerFactory.logger.error msg
   else
     Syslog.open($0, Syslog::LOG_PID | Syslog::LOG_CONS) { |s| s.err msg.to_s.gsub('%', '%%') rescue false }
   end
@@ -51,8 +53,9 @@ rescue Exception => e
 end
 
 def log_debug msg
-  if defined? ::Proxy::Log
-    ::Proxy::Log.logger.debug msg
+  if defined? ::Proxy::LoggerFactory
+    # helper methods are also used from proxy context (refresh facts -> facter API -> custom facts)
+    ::Proxy::LoggerFactory.logger.debug msg
   else
     Syslog.open($0, Syslog::LOG_PID | Syslog::LOG_CONS) { |s| s.debug msg.to_s.gsub('%', '%%') rescue false }
   end


### PR DESCRIPTION
To test this, discover host and refresh its facts, watch journald - it should
contain some logs during refresh facts like primary NIC detection. Messages
like "Detecting the first NICs with link" should be there and no errors about
already opened sylog present.

This patch also enables log buffer and configures slightly smaller buffer of
messages and errors. This can be helpful
http://projects.theforeman.org/issues/14317