### PR TITLE
Fixes #14494 - made texts branding-friendly

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery.rb
@@ -158,7 +158,7 @@ end
 
 def upload(uri = discover_server, type = proxy_type, custom_facts = {})
   unless uri
-    log_err "Could not determine Foreman instance, add foreman.url or proxy.url kernel command parameter"
+    log_err "Could not determine instance type, add foreman.url or proxy.url kernel command parameter"
     return
   end
   unless uri.is_a? URI
@@ -166,10 +166,10 @@ def upload(uri = discover_server, type = proxy_type, custom_facts = {})
     return
   end
   if uri.host.nil? or uri.port.nil?
-    log_err "Foreman URI host or port was not specified, cannot continue"
+    log_err "Server or proxy URI host or port was not specified, cannot continue"
     return
   end
-  log_msg "Registering host with Foreman (#{uri})"
+  log_msg "Registering host at (#{uri})"
   http = Net::HTTP.new(uri.host, uri.port)
   if uri.scheme == 'https' then
     http.use_ssl = true
@@ -190,18 +190,18 @@ def upload(uri = discover_server, type = proxy_type, custom_facts = {})
   req.body = {'facts' => facts }.to_json
   response = http.request(req)
   if ['200','201'].include? response.code
-    log_msg "Response from Foreman #{response.code}: #{response.body}"
+    log_msg "Response from server #{response.code}: #{response.body}"
     body = response.nil? ? 'N/A' : response.body
     write_tui 'success', response.code, body
     return true
   else
-    log_err "Response from Foreman #{response.code}: #{response.body}"
+    log_err "Response from server #{response.code}: #{response.body}"
     body = response.nil? ? 'N/A' : response.body
     write_tui 'failure', response.code, body
     return false
   end
 rescue => e
-  log_err "Could not send facts to Foreman: #{e}"
+  log_err "Could not send facts to server: #{e}"
   log_debug e.backtrace.join("\n")
   body = response.nil? ? 'N/A' : response.body
   write_tui 'failure', 1001, "#{e}, body: #{body}"

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
@@ -1,11 +1,11 @@
 def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_type = cmdline('proxy.type')
-  Newt::Screen.centered_window(59, 20, "Foreman credentials")
+  Newt::Screen.centered_window(59, 20, "Credentials")
   f = Newt::Form.new
   t_desc = Newt::Textbox.new(2, 2, 54, 6, Newt::FLAG_WRAP)
   t_desc.set_text "Provide full URL (http(s)://host:PORT) to the Server or Proxy " +
   "according to the type selected. Ports are usually 443, 8443, 8448 or 9090 according " +
   "to configuration."
-  l_url = Newt::Label.new(2, 8, "Foreman URL:")
+  l_url = Newt::Label.new(2, 8, "Server URL:")
   l_type = Newt::Label.new(2, 10, "Connection type:")
   t_url = Newt::Entry.new(20, 8, "", 36, Newt::FLAG_SCROLL)
   r_server = Newt::RadioButton.new(20, 10, "Server", 0, nil)
@@ -31,7 +31,7 @@ def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_
       proxy_url = URI.parse(url)
       raise "Port must be explicitly provided" if proxy_url.port.nil?
     rescue Exception => e
-      Newt::Screen.win_message("Invalid URL", "OK", "Not a valid Foreman URL: #{url} (#{e})")
+      Newt::Screen.win_message("Invalid URL", "OK", "Not a valid URL: #{url} (#{e})")
       return [:screen_foreman, mac, gw, url, proxy_type]
     end
     [:screen_facts, mac, proxy_url, proxy_type]

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
@@ -1,7 +1,7 @@
 def screen_primary_iface dhcp = false
   width = 60
   t_desc = Newt::Textbox.new(-1, -1, width, 3, Newt::FLAG_WRAP)
-  t_desc.set_text "Select primary (provisioning) network interface with connection to Foreman server:"
+  t_desc.set_text "Select primary (provisioning) network interface with connection to server or proxy:"
   lb_ifaces = Newt::Listbox.new(-1, -1, 10, Newt::FLAG_SCROLL)
   b_select = Newt::Button.new(-1, -1, "Select")
   b_cancel = Newt::Button.new(-1, -1, "Cancel")

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/welcome.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/welcome.rb
@@ -1,7 +1,7 @@
 def screen_welcome
   text_help, tw, th = Newt.reflow_text(<<EOT, 60, 5, 5)
 Select Manual network setup to select primary interface, configure network (no DHCP required), \
-setup Foreman server credentials, add custom facts and trigger auto-provisioning \
+setup server credentials, add custom facts and trigger auto-provisioning \
 via Discovery rules. This will lead to kernel reload (kexec) into installer. \
 Select Discover with DHCP to select primary interface and proceed with DHCP configuration \
 and standard discovery without any custom facts. This will reboot the host once the system \


### PR DESCRIPTION
@stbenjam I am removing all Foreman terms and using just Server instead
"Foreman Server" which is downstream-friendly. Filed a ticket to add full i18n
support but that's not on the table now. I don't even know if newt supports
UNICODE.