### PR TITLE
Fixes #15138 - start proxy when IPv4 is not present

### DIFF
--- a/root/usr/bin/generate-proxy-cert
+++ b/root/usr/bin/generate-proxy-cert
@@ -10,14 +10,18 @@ exportKCL
 
 DIR=/etc/foreman-proxy
 DAYS=${KCL_FDI_PROXY_CERT_DAYS:-999}
-IP=$(nmcli -t -f IP4.ADDRESS con show primary 2>/dev/null | cut -f2 -d: | cut -f1 -d/)
+
+COMMON_NAME=$(nmcli -t -f IP4.ADDRESS con show primary 2>/dev/null | cut -f2 -d: | cut -f1 -d/)
+
+# Don't fail when IP address was not provided (HTTP can be still used).
+[ -z "$COMMON_NAME" ] && COMMON_NAME=discovered
 
 openssl req -x509 \
   -newkey rsa:2048 \
   -keyout $DIR/key.pem \
   -out $DIR/cert.pem \
   -nodes \
-  -subj "/CN=$IP" \
+  -subj "/CN=$COMMON_NAME" \
   -rand /dev/urandom \
   -batch \
   -days $DAYS


### PR DESCRIPTION
When DHCP fails to deliver an IPv4 address (or on networks without DHCP),
foreman-proxy service might fail to start because HTTPS X509 CN might be empty
(openssl fails to generate cert without CN).

This patch adds a static string "discovered" there so users can still use
discovered node via HTTP. To test this, disable DHCP and start the image,
foreman-proxy should be up and running responding both on 8448 (HTTP) and 8443
(HTTPS with this common name - certificate should fail to validate of course).