### PR TITLE
Fixes #15144 - removed KMS video drivers

### DIFF
--- a/25-minimize.ks
+++ b/25-minimize.ks
@@ -21,6 +21,13 @@ blacklist mei
 install mei /bin/true
 EOMEI
 
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1335830
+echo " * remove KMS DRM video drivers to prevent kexec isues"
+rm -rf /lib/modules/*/kernel/drivers/gpu/drm /lib/firmware/{amdgpu,radeon}
+
+echo " * remove unused drivers"
+rm -rf /lib/modules/*/kernel/{sound,drivers/media,fs/nls}
+
 echo " * compressing cracklib dictionary"
 gzip -9 /usr/share/cracklib/pw_dict.pwd
 


### PR DESCRIPTION
To test this create libvirt VM with "CIRRUS" video card driver and boot the
image. Then:

```
wget http://mirror.centos.org/centos-6/6.7/os/x86_64/images/pxeboot/initrd.img
wget http://mirror.centos.org/centos-6/6.7/os/x86_64/images/pxeboot/vmlinuz
kexec --debug --initrd initrd.img vmlinuz


wget http://mirror.centos.org/centos-7/7.2.1511/os/x86_64/images/pxeboot/initrd.img
wget http://mirror.centos.org/centos-7/7.2.1511/os/x86_64/images/pxeboot/vmlinuz
kexec --debug --initrd initrd.img vmlinuz
```

You should see Anaconda coming up in TUI or dracut shell (in case of CentOS 7).
Console should not be frozen.