### PR TITLE
Fixes #9945 - add VLAN support for primary interface

### DIFF
--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -6,6 +6,7 @@ bootif="$(normalizeHwAddr "${BOOTMAC}")"
 mac=${2:-$bootif}
 uuid=$(/usr/bin/uuid)
 timeout=${KCL_FDI_DHCP_TIMEOUT:-300}
+ctype="802-3-ethernet"
 
 correct_owner_perms() {
   chown root:root $1
@@ -14,8 +15,8 @@ correct_owner_perms() {
 
 usage() {
   echo "Usage: "
-  echo " $0 primary [MAC_ADDRESS]"
-  echo " $0 primary-static MAC_ADDRESS IP4_ADDR/CIDR IP4_GW IP4_DNS"
+  echo " $0 primary MAC_ADDRESS [VPN_ID]"
+  echo " $0 primary-static MAC_ADDRESS IP4_ADDR/CIDR IP4_GW IP4_DNS [VPN_ID]"
   echo " $0 secondary MAC_ADDRESS AUTOCONNECT (true/false)"
 }
 
@@ -25,12 +26,14 @@ if [[ "$1" == "primary-static" ]]; then
   ip=$3
   gw=$4
   dns=$5
+  vlanid=${6:-$KCL_FDI_VLAN_PRIMARY}
+  [[ "$vlanid" != "" ]] && ctype="vlan"
   script=/etc/NetworkManager/system-connections/primary
   cat > $script <<EONS
 [connection]
 id=primary
 uuid=$uuid
-type=802-3-ethernet
+type=$ctype
 autoconnect=true
 autoconnect-priority=1
 [802-3-ethernet]
@@ -42,15 +45,19 @@ gateway=$gw
 dns=$dns;
 [ipv6]
 method=ignore
+[vlan]
+id=$vlanid
 EONS
   correct_owner_perms $script
 elif [[ "$1" == "primary" ]]; then
+  vlanid=${3:-$KCL_FDI_VLAN_PRIMARY}
+  [[ "$vlanid" != "" ]] && ctype="vlan"
   script=/etc/NetworkManager/system-connections/primary
   cat > $script <<EONS
 [connection]
 id=primary
 uuid=$uuid
-type=802-3-ethernet
+type=$ctype
 autoconnect=true
 autoconnect-priority=1
 [802-3-ethernet]
@@ -60,6 +67,8 @@ method=auto
 dhcp-timeout=$timeout
 [ipv6]
 method=ignore
+[vlan]
+id=$vlanid
 EONS
   correct_owner_perms $script
 elif [[ "$1" == "secondary" ]]; then

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -75,15 +75,15 @@ def start_discovery_service
   end
 end
 
-def configure_network static, mac, ip=nil, gw=nil, dns=nil
+def configure_network static, mac, ip=nil, gw=nil, dns=nil, vlan=nil
   command("systemctl stop foreman-proxy")
   if static
-    command("nm-configure primary-static '#{mac}' '#{ip}' '#{gw}' '#{dns}'")
+    command("nm-configure primary-static '#{mac}' '#{ip}' '#{gw}' '#{dns}' '#{vlan}'")
   else
-    command("nm-configure primary '#{mac}'")
+    command("nm-configure primary '#{mac}' '#{vlan}'")
   end
   command("nmcli connection reload")
-  command("nmcli connection down primary")
+  command("nmcli connection down primary", false)
   result = command("nmcli connection up primary", false)
   command("nm-online -s -q --timeout=45") unless static
   # restarting proxy with regenerated SSL self-signed cert

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/network.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/network.rb
@@ -1,4 +1,4 @@
-def screen_network mac, ip = cmdline('fdi.pxip', ''), gw = cmdline('fdi.pxgw', ''), dns = cmdline('fdi.pxdns', '')
+def screen_network mac, vlan_id, ip = cmdline('fdi.pxip', ''), gw = cmdline('fdi.pxgw', ''), dns = cmdline('fdi.pxdns', '')
   Newt::Screen.centered_window(49, 20, _("Network configuration"))
   f = Newt::Form.new
   t_desc = Newt::Textbox.new(2, 2, 44, 6, Newt::FLAG_WRAP)
@@ -26,12 +26,12 @@ def screen_network mac, ip = cmdline('fdi.pxip', ''), gw = cmdline('fdi.pxgw', '
       IPAddr.new(ip); IPAddr.new(gw); IPAddr.new(dns)
     rescue Exception => e
       Newt::Screen.win_message(_("Invalid IP"), _("OK"), _("Provide valid CIDR ipaddress with a netmask, gateway and one DNS server"))
-      return [:screen_network, mac, ip, gw, dns]
+      return [:screen_network, mac, vlan_id, ip, gw, dns]
     end
-    action = Proc.new { configure_network true, mac, ip, gw, dns }
+    action = Proc.new { configure_network true, mac, ip, gw, dns, vlan_id }
     [:screen_info, action, _("Configuring network. This operation can take several minutes to complete."), _("Unable to bring up network"),
       [:screen_foreman, mac, gw],
-      [:screen_network, mac, ip, gw, dns]]
+      [:screen_network, mac, vlan_id, ip, gw, dns]]
   else
     :screen_welcome
   end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
@@ -1,17 +1,20 @@
 def screen_primary_iface dhcp = false
+  bootif = normalize_mac(cmdline('BOOTIF'))
+  preselectedif = normalize_mac(cmdline('fdi.pxmac'))
+  vlanid = cmdline('fdi.vlan.primary', '')
+
   width = 60
   t_desc = Newt::Textbox.new(-1, -1, width, 3, Newt::FLAG_WRAP)
   t_desc.set_text _("Select primary (provisioning) network interface with connection to server or proxy:")
-  lb_ifaces = Newt::Listbox.new(-1, -1, 10, Newt::FLAG_SCROLL)
+  lb_ifaces = Newt::Listbox.new(-1, -1, 7, Newt::FLAG_SCROLL)
+  l_vlan = Newt::Label.new(-1, -1, "VLAN ID:")
+  t_vlan = Newt::Entry.new(-1, -1, vlanid, 10, Newt::FLAG_SCROLL)
   b_select = Newt::Button.new(-1, -1, _("Select"))
   b_cancel = Newt::Button.new(-1, -1, _("Cancel"))
   lb_ifaces.set_width(width)
 
-  bootif = normalize_mac(cmdline('BOOTIF'))
-  preselectedif = normalize_mac(cmdline('fdi.pxmac'))
   log_msg "Building net interfaces TUI (bootif=#{bootif})"
   ix = 0
-  #if_names = {}
   Dir.glob('/sys/class/net/*') do |ifn|
     name = File.basename ifn
     next if name == "lo"
@@ -24,37 +27,42 @@ def screen_primary_iface dhcp = false
     lb_ifaces.append "#{mac} #{name} #{' (link up)' if link} #{' (pxebooted)' if booted}", mac
     lb_ifaces.set_current ix if booted || preselected
     ix = ix + 1
-    #if_names[mac] = name
   end
 
-  main_grid = Newt::Grid.new(1, 3)
+  main_grid = Newt::Grid.new(1, 4)
   but_grid = Newt::Grid.new(2, 1)
+  vlan_grid = Newt::Grid.new(2, 1)
 
   but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_select, 0, 0, 0, 0, 0, 0)
   but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_cancel, 0, 0, 0, 0, 0, 0)
 
+  vlan_grid.set_field(0, 0, Newt::GRID_COMPONENT, l_vlan, 0, 0, 0, 0, 0, 0)
+  vlan_grid.set_field(1, 0, Newt::GRID_COMPONENT, t_vlan, 0, 0, 0, 0, 0, 0)
+
   main_grid.set_field(0, 0, Newt::GRID_COMPONENT, t_desc, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
   main_grid.set_field(0, 1, Newt::GRID_COMPONENT, lb_ifaces, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
-  main_grid.set_field(0, 2, Newt::GRID_SUBGRID, but_grid, 0, 1, 0, 0, 0, Newt::GRID_FLAG_GROWX)
+  main_grid.set_field(0, 2, Newt::GRID_SUBGRID, vlan_grid, 0, 1, 0, 0, 0, 0)
+  main_grid.set_field(0, 3, Newt::GRID_SUBGRID, but_grid, 0, 1, 0, 0, 0, Newt::GRID_FLAG_GROWX)
   main_grid.wrapped_window(_("Primary interface"))
 
   f = Newt::Form.new
   if preselectedif
-    f.add(b_select, b_cancel, t_desc, lb_ifaces)
+    f.add(b_select, b_cancel, t_desc, lb_ifaces, l_vlan, t_vlan)
   else
-    f.add(t_desc, lb_ifaces, b_select, b_cancel)
+    f.add(t_desc, lb_ifaces, l_vlan, t_vlan, b_select, b_cancel)
   end
   answer = f.run()
   if answer == b_select
     primary_mac = lb_ifaces.get_current_as_string
+    vlan_id = t_vlan.get
     if dhcp
-      action = Proc.new { configure_network false, primary_mac }
+      action = Proc.new { configure_network false, primary_mac, nil, nil, nil, vlan_id }
       [:screen_info, action, _("Configuring network via DHCP. This operation can take several minutes to complete."), _("Unable to bring network via DHCP"),
         [:screen_foreman, primary_mac, nil, cmdline('proxy.url'), cmdline('proxy.type')],
-        [:screen_network, primary_mac]]
+        [:screen_network, primary_mac, vlan_id]]
     else
       detect_ip, detect_gw, detect_dns = detect_ipv4_credentials('primary')
-      [:screen_network, primary_mac, cmdline('fdi.pxip', detect_ip), cmdline('fdi.pxgw', detect_gw), cmdline('fdi.pxdns', detect_dns)]
+      [:screen_network, primary_mac, vlan_id, cmdline('fdi.pxip', detect_ip), cmdline('fdi.pxgw', detect_gw), cmdline('fdi.pxdns', detect_dns)]
     end
   elsif answer == b_cancel
     :screen_welcome


### PR DESCRIPTION
This will work in both PXE and PXE-less modes. Use `fdi.vlan.primary=10` to set
VLAN ID to 10 for the primary interface via kernel command line or use new VLAN
text option on the Primary Interface screen to configure it in PXE-less.