### PR TITLE
Fixes #16419 - search domains honored during SRV

### DIFF
--- a/25-minimize.ks
+++ b/25-minimize.ks
@@ -38,12 +38,12 @@ rpm -e syslinux mtools acl
 # 100MB of locale archive is kind unnecessary; we only do en_US.utf8
 # this will clear out everything we don't need; 100MB => 2.1MB.
 echo " * minimizing locale-archive binary / memory size"
-localedef --list-archive | grep -iv 'en_US' | xargs localedef -v --delete-from-archive
+localedef --list-archive | grep -Eiv '(en_US|fdi)' | xargs localedef -v --delete-from-archive
 mv /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
 /usr/sbin/build-locale-archive
 
 echo " * purging all other locale data"
-rm -rf /usr/share/locale*
+ls -d /usr/share/locale/* | grep -v fdi | xargs rm -rf
 
 echo " * purging images"
 rm -rf /usr/share/backgrounds/* /usr/share/kde4/* /usr/share/anaconda/pixmaps/rnotes/*

--- a/aux/vagrant-build/Vagrantfile
+++ b/aux/vagrant-build/Vagrantfile
@@ -6,8 +6,8 @@ boxes = [
   {:name => 'wheezy',   :libvirt => 'fm-debian7',    :image_name => /Debian.*7/,      :os_user => 'debian'},
   {:name => 'f19',      :libvirt => 'fm-fedora19',   :image_name => /Fedora.*19/, :pty => true},
   {:name => 'f20',      :libvirt => 'fm-fedora20',   :image_name => /Fedora.*20.*PVHVM/, :pty => true},
-  {:name => 'f21',      :libvirt => 'fm-fedora21',   :image_name => /Fedora.*21.*PVHVM/, :pty => true},
-  {:name => 'f22',      :libvirt => 'fm-fedora22',   :image_name => /Fedora.*22.*PVHVM/, :pty => true},
+  {:name => 'f23',      :libvirt => 'fm-fedora23',   :image_name => /Fedora.*23.*PVHVM/, :pty => true},
+  {:name => 'f24',      :libvirt => 'fm-fedora24',   :image_name => /Fedora.*24.*PVHVM/, :pty => true},
   {:name => 'el6',      :libvirt => 'fm-centos64',   :image_name => /CentOS 6\.5 SELinux/, :default => true, :pty => true},
   # There is no livecd-tools available in EPEL7 therefore we build on F20
   {:name => 'el7',      :libvirt => 'fm-centos70',   :image_name => /CentOS 7/, :default => true, :pty => true},

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -132,7 +132,7 @@ begin
   selected_locale = cmdline('locale')
   FastGettext.locale = selected_locale if selected_locale
 rescue Exception => e
-  log_err "Unable to initialize gettext: #{e}"
+  error_box("Unable to initialize gettext: #{e}", e) unless e.is_a? SystemExit
 end
 include FastGettext::Translation
 

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/facts.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/facts.rb
@@ -13,7 +13,7 @@ def screen_facts mac, proxy_url, proxy_type
 
   names = []; values = []; labels = []; labels_sep = []
   (0..8).each_with_index do |ix, _|
-    labels[ix] = Newt::Label.new(-1, -1, (_("Fact %s name") % ('#' + ix + 1)) + ' ')
+    labels[ix] = Newt::Label.new(-1, -1, (_("Fact %s name") % ('#' + (ix + 1).to_s)) + ' ')
     labels_sep[ix] = Newt::Label.new(-1, -1, ' ' + _('value') + ' ')
     names[ix] = Newt::Entry.new(-1, -1, cmdline("fdi.pxfactname#{ix + 1}").to_s, 15, Newt::FLAG_SCROLL)
     values[ix] = Newt::Entry.new(-1, -1, cmdline("fdi.pxfactvalue#{ix + 1}").to_s, 15, Newt::FLAG_SCROLL)


### PR DESCRIPTION
Workarounds: https://bugs.ruby-lang.org/issues/11152

The patch also adds 'fdi.srv.scheme' new option to set http or https scheme for
custom port.