### PR TITLE
Fixes #16526 - added biosdevname package

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -1,6 +1,7 @@
 %packages --excludedocs
 bash
 kernel
+biosdevname
 grub2
 grub2-tools
 e2fsprogs


### PR DESCRIPTION
Unless you test this on DELL system, you can't really see any difference.
Ensure the presence of biosdevname command and that's it.