### PR TITLE
Fixes #19220 - properly handle SIGTERM in menu

### DIFF
--- a/root/etc/systemd/system/discovery-menu.service
+++ b/root/etc/systemd/system/discovery-menu.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Display interactive TUI on tty1
+Description=Discovery TUI
 Wants=basic.target
 After=basic.target network.target nss-lookup.target
 ConditionPathExists=/dev/tty1
@@ -10,8 +10,9 @@ EnvironmentFile=/etc/default/discovery
 ExecStart=/usr/bin/discovery-menu
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
-RestartSec=3
+RestartSec=5
 KillMode=process
+TimeoutStopSec=5
 StandardInput=tty
 StandardError=tty
 StandardOutput=tty

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -117,6 +117,7 @@ end
 
 def cleanup
   Newt::Screen.finish
+  exit 0
 end
 
 log_msg "Kernel opts: #{cmdline}"


### PR DESCRIPTION
Looks like menu is blocking it, does not respond to TERM and systemd waits 1:30
minute to send TERM. The signal had a handler but it just cleared screen and it
never exited the process. Whoopsy.