### PR TITLE
Fixes #19950 - Remove superfluous nmcli commands

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -82,8 +82,6 @@ def configure_network static, mac, ip=nil, gw=nil, dns=nil, vlan=nil
   else
     command("nm-configure primary '#{mac}' '#{vlan}'")
   end
-  command("nmcli connection reload")
-  command("nmcli connection down primary", false)
   result = command("nmcli connection up primary", false)
   command("nm-online -s -q --timeout=45") unless static
   # restarting proxy with regenerated SSL self-signed cert


### PR DESCRIPTION
Since NetworkManager detects new the profile and reloads
it, we can remove reload/down commands completely.