### PR TITLE
Fixes #20127,#20128 - nm autoloading and atomicity

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -15,8 +15,8 @@ cat > /etc/NetworkManager/NetworkManager.conf <<'NM'
 [main]
 monitor-connection-files=yes
 no-auto-default=*
-#[logging]
-#level=DEBUG
+[logging]
+level=DEBUG
 NM
 cat > /etc/udev/rules.d/81-nm-prepare.rules <<'UDEV'
 ACTION=="add", SUBSYSTEM=="net", NAME!="lo", RUN+="/usr/bin/systemd-cat -t nm-prepare /usr/bin/nm-prepare %k"

--- a/root/usr/bin/generate-proxy-cert
+++ b/root/usr/bin/generate-proxy-cert
@@ -10,8 +10,14 @@ exportKCL
 
 DIR=/etc/foreman-proxy
 DAYS=${KCL_FDI_PROXY_CERT_DAYS:-999}
-
-COMMON_NAME=$(nmcli -t -f IP4.ADDRESS con show primary 2>/dev/null | cut -f2 -d: | cut -f1 -d/)
+WAIT=${KCL_FDI_NMWAIT:-120}
+SECONDS=0
+while (( SECONDS < 60 )); do
+  sleep 1
+  COMMON_NAME=$(nmcli -w $WAIT -t -f IP4.ADDRESS con show primary 2>/dev/null | cut -f2 -d: | cut -f1 -d/)
+  [ ! -z "$COMMON_NAME" ] && break
+  logger "Waiting for IP4 address to generate SSL cert ($SECONDS)"
+done
 
 # Don't fail when IP address was not provided (HTTP can be still used).
 [ -z "$COMMON_NAME" ] && COMMON_NAME=discovered

--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -8,9 +8,10 @@ uuid=$(/usr/bin/uuid)
 timeout=${KCL_FDI_DHCP_TIMEOUT:-300}
 ctype="802-3-ethernet"
 
-correct_owner_perms() {
+deploy_config() {
   chown root:root $1
   chmod 600 $1
+  mv $1 $2
 }
 
 usage() {
@@ -22,6 +23,12 @@ usage() {
 
 [[ -z "$mac" ]] && echo "MAC address was not provided or detected, leaving unconfigured" && exit 0
 
+function cleanup() {
+  [ -f $TMP_CFG ] && rm -f $TMP_CFG
+}
+TMP_CFG=$(mktemp)
+trap cleanup EXIT SIGINT SIGTERM
+
 if [[ "$1" == "primary-static" ]]; then
   ip=$3
   gw=$4
@@ -29,13 +36,14 @@ if [[ "$1" == "primary-static" ]]; then
   vlanid=${6:-$KCL_FDI_VLAN_PRIMARY}
   [[ "$vlanid" != "" ]] && ctype="vlan"
   script=/etc/NetworkManager/system-connections/primary
-  cat > $script <<EONS
+  cat > $TMP_CFG <<EONS
 [connection]
 id=primary
 uuid=$uuid
 type=$ctype
 autoconnect=true
 autoconnect-priority=1
+may-fail=false
 [802-3-ethernet]
 mac-address=$mac
 [ipv4]
@@ -48,18 +56,19 @@ method=ignore
 [vlan]
 id=$vlanid
 EONS
-  correct_owner_perms $script
+  deploy_config $TMP_CFG $script
 elif [[ "$1" == "primary" ]]; then
   vlanid=${3:-$KCL_FDI_VLAN_PRIMARY}
   [[ "$vlanid" != "" ]] && ctype="vlan"
   script=/etc/NetworkManager/system-connections/primary
-  cat > $script <<EONS
+  cat > $TMP_CFG <<EONS
 [connection]
 id=primary
 uuid=$uuid
 type=$ctype
 autoconnect=true
 autoconnect-priority=1
+may-fail=false
 [802-3-ethernet]
 mac-address=$mac
 [ipv4]
@@ -71,17 +80,18 @@ method=ignore
 [vlan]
 id=$vlanid
 EONS
-  correct_owner_perms $script
+  deploy_config $TMP_CFG $script
 elif [[ "$1" == "secondary" ]]; then
   autoconnect=$3
   id=secondary-$mac
   script=/etc/NetworkManager/system-connections/$id
-  cat > $script <<EONS
+  cat > $TMP_CFG <<EONS
 [connection]
 id=$id
 uuid=$uuid
 type=802-3-ethernet
 autoconnect=$autoconnect
+may-fail=true
 [802-3-ethernet]
 mac-address=$mac
 [ipv4]
@@ -94,7 +104,7 @@ dhcp-send-hostname=false
 [ipv6]
 method=ignore
 EONS
-  correct_owner_perms $script
+  deploy_config $TMP_CFG $script
 else
   usage
 fi

--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -43,7 +43,6 @@ uuid=$uuid
 type=$ctype
 autoconnect=true
 autoconnect-priority=1
-may-fail=false
 [802-3-ethernet]
 mac-address=$mac
 [ipv4]
@@ -68,7 +67,6 @@ uuid=$uuid
 type=$ctype
 autoconnect=true
 autoconnect-priority=1
-may-fail=false
 [802-3-ethernet]
 mac-address=$mac
 [ipv4]
@@ -91,7 +89,6 @@ id=$id
 uuid=$uuid
 type=802-3-ethernet
 autoconnect=$autoconnect
-may-fail=true
 [802-3-ethernet]
 mac-address=$mac
 [ipv4]

--- a/root/usr/lib64/ruby/vendor_ruby/discovery.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery.rb
@@ -225,11 +225,13 @@ def env_append(env,string)
 end
 
 def get_mac(interface = 'primary')
-  `nmcli -t -f 802-3-ethernet.mac-address con show #{interface} 2>/dev/null`.scan(/\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2}\n/).first.strip rescue 'N/A'
+  wait = cmdline('fdi.nmwait', 120)
+  `nmcli -w #{wait} -t -f 802-3-ethernet.mac-address con show #{interface} 2>/dev/null`.scan(/\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2}\n/).first.strip rescue 'N/A'
 end
 
 def get_ipv4(interface = 'primary')
-  `nmcli -t -f IP4.ADDRESS con show #{interface} 2>/dev/null`.scan(/\d+\.\d+\.\d+\.\d+\/\d+\n/).first.strip rescue 'N/A'
+  wait = cmdline('fdi.nmwait', 120)
+  `nmcli -w #{wait} -t -f IP4.ADDRESS con show #{interface} 2>/dev/null`.scan(/\d+\.\d+\.\d+\.\d+\/\d+\n/).first.strip rescue 'N/A'
 end
 
 def detect_ipv4_credentials(interface)

--- a/root/usr/share/fdi/facts/discovery-facts.rb
+++ b/root/usr/share/fdi/facts/discovery-facts.rb
@@ -170,7 +170,8 @@ if has_ipmi
 end
 
 # NetworkManager details (e.g. nmprimary_dhcp4_option_domain_name)
-nmout = Facter::Util::Resolution.exec("nmcli -t con show primary 2>/dev/null")
+wait = cmdline('fdi.nmwait', 120)
+nmout = Facter::Util::Resolution.exec("nmcli -w #{wait} -t con show primary 2>/dev/null")
 nmout.each_line do |x|
   elements = x.split(":", 2)
   name = elements.first.downcase.sub(/\[\d+\]$/,"")


### PR DESCRIPTION
For easier testing, two patches in one PR, P1:

NetworkManager monitors configuration profile changes and automatically
reloads configurations. This patch makes sure it's atomic file system
change (move) rather than create/modify owner/perms which confused NM
issuing warnings about insecure permissions.

P2 is all about autoloading of nm, we have configured NM to detect profile changes and reload automatically (see 22-discovery.ks) but then we issue "down" and "reload" commands via nmcli. We need to pick either one or the other approach - it looks like keeping autoloading (configuration file monitoring) is better for PXE startup, therefore I removed the "nmcli con down" command (which also fixes 19950 issue) and the code now relies heavily on NM ability to detect the change.

Also we touched the configuration file three times (create, chown, chmod) which caused warnings and extra reloading in NM, so I changed the code to atomically move the file to the destination.

During testing I hit an issue when HTTPS SSL certificate for proxy (its executed during startup of the service) was started *before* IP address is ackquired (nm-online does not wait for IP4 DHCP to complete), therefore I added a code that waits one minute and every second it attempts to read IPv4 address from NM - when it appears, the certificate is generated with correct COMMON NAME (of the given IP), otherwise it falls back to "discovered" string.