### PR TITLE
Fixes #20603 - Disable kernel messages on tty1

### DIFF
--- a/root/etc/systemd/system/discovery-menu.service
+++ b/root/etc/systemd/system/discovery-menu.service
@@ -8,6 +8,7 @@ ConditionPathExists=/dev/tty1
 Type=idle
 EnvironmentFile=/etc/default/discovery
 ExecStart=/usr/bin/discovery-menu
+ExecStartPre=/usr/sbin/sysctl -w kernel.printk=0
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5

--- a/root/usr/bin/discovery-debug
+++ b/root/usr/bin/discovery-debug
@@ -39,7 +39,7 @@ echo "* IMAGE VERSION"
 cat /usr/share/fdi/VERSION /usr/share/fdi/RELEASE
 
 echo "* FACTER *"
-facter
+FACTERLIB=/usr/share/fdi/facts/ facter --json
 
 echo "* JOURNAL (last 500 lines) *"
 journalctl -n300 -ocat


### PR DESCRIPTION
After PXE-less boot, sign in onto the image and verify:

[lzap@box ~]$ sysctl kernel.printk
kernel.printk = 0       4       1       7

That the first column is zero so kernel will not print any messages on tty.