### PR TITLE
UX rename Proxy to Smary Proxy

### DIFF
--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
@@ -2,12 +2,12 @@ def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_
   Newt::Screen.centered_window(59, 20, _("Credentials"))
   f = Newt::Form.new
   t_desc = Newt::Textbox.new(2, 2, 54, 6, Newt::FLAG_WRAP)
-  t_desc.set_text _("Provide full URL (http(s)://host:PORT) to the Server or Proxy according to the type selected. Ports are usually 443, 8443, 8448 or 9090 according to configuration.")
+  t_desc.set_text _("Provide full URL (http(s)://host:PORT) to the Server or Foreman Proxy according to the type selected. Ports are usually 443, 8443, 8448 or 9090 according to configuration.")
   l_url = Newt::Label.new(2, 8, _("Server URL:"))
   l_type = Newt::Label.new(2, 10, _("Connection type:"))
   t_url = Newt::Entry.new(20, 8, "", 36, Newt::FLAG_SCROLL)
   r_server = Newt::RadioButton.new(20, 10, _("Server"), 0, nil)
-  r_proxy = Newt::RadioButton.new(32, 10, _("Proxy"), 1, r_server)
+  r_proxy = Newt::RadioButton.new(32, 10, _("Foreman Proxy"), 1, r_server)
   b_ok = Newt::Button.new(34, 15, _("Next"))
   b_cancel = Newt::Button.new(46, 15, _("Cancel"))
   proxy_type ||= 'foreman'


### PR DESCRIPTION
Small thing, but `Proxy` could be confused with HTTP proxy.