### PR TITLE
Fixes #22112 - PXE-less DHCP first attempt fixed

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -13,7 +13,7 @@ systemctl disable kdump.service
 echo " * configuring NetworkManager and udev/nm-prepare"
 cat > /etc/NetworkManager/NetworkManager.conf <<'NM'
 [main]
-monitor-connection-files=yes
+monitor-connection-files=no
 no-auto-default=*
 [logging]
 level=DEBUG
@@ -56,6 +56,7 @@ sed -i '/\[Unit\]/a ConditionPathExists=/etc/NetworkManager/system-connections/p
 sed -i '/\[Service\]/a EnvironmentFile=-/etc/default/discovery' /usr/lib/systemd/system/foreman-proxy.service
 sed -i '/\[Service\]/a ExecStartPre=/usr/bin/generate-proxy-cert' /usr/lib/systemd/system/foreman-proxy.service
 sed -i '/\[Service\]/a PermissionsStartOnly=true' /usr/lib/systemd/system/foreman-proxy.service
+sed -i '/\[Service\]/a TimeoutStartSec=9999' /usr/lib/systemd/system/foreman-proxy.service
 /sbin/usermod -a -G tty foreman-proxy
 
 cat >/etc/foreman-proxy/settings.yml <<'CFG'

--- a/root/usr/bin/generate-proxy-cert
+++ b/root/usr/bin/generate-proxy-cert
@@ -10,13 +10,13 @@ exportKCL
 
 DIR=/etc/foreman-proxy
 DAYS=${KCL_FDI_PROXY_CERT_DAYS:-999}
-WAIT=${KCL_FDI_NMWAIT:-120}
+WAIT=${KCL_FDI_IPWAIT:-120}
 SECONDS=0
-while (( SECONDS < 60 )); do
+while (( SECONDS < $WAIT )); do
   sleep 1
-  COMMON_NAME=$(nmcli -w $WAIT -t -f IP4.ADDRESS con show primary 2>/dev/null | cut -f2 -d: | cut -f1 -d/)
+  COMMON_NAME=$(nmcli -w 1 -t -f IP4.ADDRESS con show primary 2>/dev/null | cut -f2 -d: | cut -f1 -d/)
   [ ! -z "$COMMON_NAME" ] && break
-  logger "Waiting for IP4 address to generate SSL cert ($SECONDS)"
+  logger "Waiting for IP4 address to generate SSL cert ($SECONDS/$WAIT)"
 done
 
 # Don't fail when IP address was not provided (HTTP can be still used).

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -82,12 +82,12 @@ def configure_network static, mac, ip=nil, gw=nil, dns=nil, vlan=nil
   else
     command("nm-configure primary '#{mac}' '#{vlan}'")
   end
-  # NetworkManager monitors config files and auto connects immediately
   wait = cmdline('fdi.nmwait', 120)
-  result = command("nm-online -s -q --timeout=#{wait}")
-  # restarting proxy with regenerated SSL self-signed cert
-  command("systemctl start foreman-proxy")
-  result
+  command("nmcli -w #{wait} connection reload", false)
+  up_result = command("nmcli -w #{wait} connection up primary", false)
+  command("nm-online -s -q --timeout=#{wait}")
+  # wait for IPv4, generate SSL self-signed cert and start proxy
+  command("systemctl start foreman-proxy") && up_result
 end
 
 def perform_upload proxy_url, proxy_type, custom_facts


### PR DESCRIPTION
This patch aims fixing two issues. First, in PXE-less mode when DHCP configuration was selected, the first attempt always failed. The patch changes behavior of NetworkManager - it will not detect configuration file changes automatically anymore but it must be explicitly started via "nmcli c up" now (one exception is when NetworkManager starts up).

Second, when `fdi.dhcp_timeout` option was provided (defaults to 120) it did not have an effect. This was due to waiting loop, it was essentially fixed to 60 seconds. It turns out that -w / --wait options for nmcli has no effect in waiting for IP address. It is basically just a timeout for NetworkManager connection (DBUS) or other actions, now the loop respects the timeout value.

Please test both PXE less (with/without DHCP) and PXE workflows.