### PR TITLE
Fixes #23771 - Refactor TUI for modularity and image-based screens

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -75,6 +75,15 @@ grub2-efi-x64
 grub2-efi-x64-cdboot
 shim-x64
 
+# Volume, filesystem and image management
+mdadm
+parted
+ssm
+xfsprogs
+
+# Optional packages - when removed some functionality will not be available
+udpcast
+
 # tools that enable the image installer plugin
 parted
 mdadm

--- a/build-livecd-root
+++ b/build-livecd-root
@@ -35,7 +35,7 @@ cd $tmpdir
 echo Working in directory $tmpdir
 
 echo "* Running livecd-creator"
-livecd-creator -v --title="Discovery Image" --compression-type=xz --cache /var/cache/build-fdi --config $srcdir/fdi-image.ks -f fdi -t /tmp
+livecd-creator -v --product="Discovery Image" --title="Foreman" --compression-type=xz --cache /var/cache/build-fdi --config $srcdir/fdi-image.ks -f fdi -t /tmp
 
 if [ $? -ne 0 ]; then
     KEEP_TMPDIR=yes

--- a/root/usr/bin/discovery-menu
+++ b/root/usr/bin/discovery-menu
@@ -13,9 +13,17 @@ require 'discovery/screen/ssh'
 require 'discovery/screen/status'
 require 'discovery/screen/welcome'
 require 'discovery/screen/info'
+require 'discovery/screen/image_mode'
+require 'discovery/screen/image_compress'
+require 'discovery/screen/image_udpcast'
+require 'discovery/screen/image_http'
 
 # Disable GC until https://github.com/theforeman/ruby-newt/issues/2 is fixed,
 # see also: http://projects.theforeman.org/issues/11623
 GC.disable
 
-main_loop
+if cmdline('fdi.noregister')
+  main_loop :screen_status
+else
+  main_loop ARGV
+end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/pipeline.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/pipeline.rb
@@ -1,0 +1,55 @@
+require 'ostruct'
+require 'singleton'
+require 'forwardable'
+
+class Pipeline
+  include Singleton
+  extend SingleForwardable
+  attr_reader :data, :gdata
+
+  def initialize
+    start_over
+    # global workflow data (variables shared for whole app)
+    @gdata = OpenStruct.new
+  end
+
+  def start_over
+    # queue of screens
+    @screens = []
+    # workflow data (variables shared for set of screens)
+    @data = OpenStruct.new
+  end
+
+  def cancel(on_cancel = :screen_welcome)
+    start_over
+    append :screen_welcome
+  end
+
+  def prepend screen
+    @screens.unshift screen
+    log_msg "Pipeline prepend (#{screen.inspect}): #{@screens.inspect}"
+    @screens
+  end
+
+  def append screen
+    @screens << screen
+    log_msg "Pipeline append (#{screen.inspect}): #{@screens.inspect}"
+    @screens
+  end
+
+  def next
+    x = @screens.shift
+    log_msg "Pipeline next (#{x.inspect}): #{@screens.inspect}"
+    x
+  end
+
+  def to_s
+    @data.to_h.to_a.map do |k, v|
+      "#{k}: #{v}"
+    end.join("\n")
+  end
+
+  def method_missing(method, *args)
+    @screens.send(method, *args)
+  end
+end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/countdown.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/countdown.rb
@@ -1,4 +1,4 @@
-def screen_countdown discovery_only = false
+def screen_countdown pipeline
   text_help, tw, th = Newt.reflow_text(_('This system will attempt to configure all interfaces via DHCP and discover itself by sending hardware facts to Foreman instance. To interrupt this behavior, press a key to be able to do manual network configuration and additional provisioning settings.'), 60, 5, 5)
   t = Newt::Textbox.new(-1, -1, tw, th, Newt::FLAG_WRAP)
   t.set_text(text_help)
@@ -19,7 +19,7 @@ def screen_countdown discovery_only = false
   f.add(t, l_press)
   f.draw
   key_was_pressed = false
-  unless discovery_only
+  unless pipeline.data.discovery_only
     sec = secs
     while sec > 0
       l_press.set_text("< " + _('Press any key') + " ... (#{sec}s) >")
@@ -34,7 +34,7 @@ def screen_countdown discovery_only = false
   end
 
   if key_was_pressed
-    :screen_welcome
+    Pipeline.instance << :screen_welcome
   else
     start_discovery_service
     # additional countdown to let discovery-register do its work
@@ -49,6 +49,6 @@ def screen_countdown discovery_only = false
       break if File.exist?("/tmp/discovery-http-failure")
       sleep 1
     end
-    :screen_status
+    Pipeline.instance << :screen_status
   end
 end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/facts.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/facts.rb
@@ -1,5 +1,5 @@
-def screen_facts mac, proxy_url, proxy_type
-  custom_facts = new_custom_facts(mac)
+def screen_facts pipeline
+  custom_facts = new_custom_facts(pipeline.data.primary_mac)
 
   b_confirm = Newt::Button.new(-1, -1, _("Confirm"))
   b_cancel = Newt::Button.new(-1, -1, _("Cancel"))
@@ -38,7 +38,7 @@ def screen_facts mac, proxy_url, proxy_type
     (0..8).each_with_index do |ix, _|
       custom_facts[names[ix].get] = values[ix].get if names[ix].get && values[ix].get
     end
-    if perform_upload(proxy_url, proxy_type, custom_facts)
+    if perform_upload(pipeline.data.proxy_url, pipeline.data.proxy_type, custom_facts)
       [:screen_status, generate_info(' - ' + _('awaiting kexec into installer'))]
     else
       [:screen_status, generate_info(' - ' + _('fact upload failed'))]

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/foreman.rb
@@ -1,4 +1,6 @@
-def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_type = cmdline('proxy.type')
+def screen_foreman pipeline
+  proxy_url = cmdline('proxy.url', pipeline.data.proxy_url)
+  proxy_type = cmdline('proxy.type', pipeline.data.proxy_type)
   Newt::Screen.centered_window(59, 20, _("Credentials"))
   f = Newt::Form.new
   t_desc = Newt::Textbox.new(2, 2, 54, 6, Newt::FLAG_WRAP)
@@ -11,7 +13,7 @@ def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_
   b_ok = Newt::Button.new(34, 15, _("Next"))
   b_cancel = Newt::Button.new(46, 15, _("Cancel"))
   proxy_type ||= 'foreman'
-  t_url.set(proxy_url, 1) if proxy_url
+  t_url.set(proxy_url.to_s, 1) if proxy_url
   r_server.set(proxy_type != 'proxy' ? '*' : ' ')
   r_proxy.set(proxy_type == 'proxy' ? '*' : ' ')
   items = [t_desc, l_type, l_url, t_url, r_server, r_proxy]
@@ -34,8 +36,10 @@ def screen_foreman mac = nil, gw = nil, proxy_url = cmdline('proxy.url'), proxy_
       Newt::Screen.win_message(_("Invalid URL"), _("OK"), _("Not a valid URL") + ": #{url} (#{e})")
       return [:screen_foreman, mac, gw, url, proxy_type]
     end
-    [:screen_facts, mac, proxy_url, proxy_type]
+    pipeline.data.proxy_url = proxy_url
+    pipeline.data.proxy_type = proxy_type
+    pipeline.append :screen_facts
   else
-    :screen_welcome
+    pipeline.cancel :screen_welcome
   end
 end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_compress.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_compress.rb
@@ -1,0 +1,49 @@
+def screen_image_compress pipeline
+  b_next = Newt::Button.new(-1, -1, _("Next"))
+  b_cancel = Newt::Button.new(-1, -1, _("Cancel"))
+
+  width = 50
+  t_desc = Newt::Textbox.new(-1, -1, width, 4, Newt::FLAG_WRAP)
+  t_desc.set_text _("Raw images may contain lots of nulls, it is good idea to compress them. Select (de)compressor to use.")
+
+  top_grid = Newt::Grid.new(1, 3)
+  form_grid = Newt::Grid.new(1, 5)
+  but_grid = Newt::Grid.new(2, 1)
+
+  # set_field(column, row, type, value, pad_left, pad_top, pad_right, pad_bottom, anchor, flags)
+  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_next, 1, 0, 1, 0, 0, 0)
+  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_cancel, 1, 0, 1, 0, 0, 0)
+
+  r_none = Newt::RadioButton.new(-1, -1, _("No compression"), 1, nil)
+  r_gzip = Newt::RadioButton.new(-1, -1, _("gzip"), 0, r_none)
+  r_bz2 = Newt::RadioButton.new(-1, -1, _("bzip2"), 0, r_gzip)
+  r_xz = Newt::RadioButton.new(-1, -1, _("xz"), 0, r_bz2)
+  r_lzop = Newt::RadioButton.new(-1, -1, _("lzop"), 0, r_xz)
+
+  form_grid.set_field(0, 0, Newt::GRID_COMPONENT, r_none, 0, 0, 1, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 1, Newt::GRID_COMPONENT, r_gzip, 0, 0, 0, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 2, Newt::GRID_COMPONENT, r_bz2, 0, 0, 0, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 3, Newt::GRID_COMPONENT, r_xz, 0, 0, 0, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 4, Newt::GRID_COMPONENT, r_lzop, 0, 0, 0, 1, Newt::ANCHOR_LEFT, 0)
+
+  top_grid.set_field(0, 0, Newt::GRID_COMPONENT, t_desc, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
+  top_grid.set_field(0, 1, Newt::GRID_SUBGRID, form_grid, 0, 0, 0, 0, 0, 0)
+  top_grid.set_field(0, 2, Newt::GRID_SUBGRID, but_grid, 0, 0, 0, 0, 0, 0)
+
+  top_grid.wrapped_window(_("Image transfer - compression"))
+
+  f = Newt::Form.new
+  f.add(t_desc, r_none, r_gzip, r_bz2, r_xz, r_lzop)
+  f.add(b_next, b_cancel)
+  answer = f.run
+  if answer == b_next
+    compress_cmds = ["cat", "gzip -c", "bzip2 -c", "xz -c", "lzop -c"]
+    uncompress_cmds = ["cat", "gzip -d", "bzip2 -d", "xz -d", "lzop -d"]
+    [r_none, r_gzip, r_bz2, r_xz, r_lzop].each_with_index do |rb, i|
+      pipeline.data.compress_cmd = compress_cmds[i] if rb.get == '*'
+      pipeline.data.uncompress_cmd = uncompress_cmds[i] if rb.get == '*'
+    end
+  else
+    pipeline.cancel :screen_image_mode
+  end
+end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_http.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_http.rb
@@ -1,0 +1,51 @@
+def screen_image_http pipeline
+  b_start = Newt::Button.new(-1, -1, _("Start"))
+  b_cancel = Newt::Button.new(-1, -1, _("Cancel"))
+
+  width = 50
+  t_desc = Newt::Textbox.new(-1, -1, width, 4, Newt::FLAG_WRAP)
+  t_desc.set_text _("Provide URL of a RAW image. When using compression, make sure it's not in a tarball (e.g. raw.gz or img.bz2 instead of tar.gz).")
+
+  top_grid = Newt::Grid.new(1, 3)
+  form_grid = Newt::Grid.new(2, 1)
+  but_grid = Newt::Grid.new(2, 1)
+
+  # set_field(column, row, type, value, pad_left, pad_top, pad_right, pad_bottom, anchor, flags)
+  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_start, 1, 0, 1, 0, 0, 0)
+  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_cancel, 1, 0, 1, 0, 0, 0)
+
+  l_url = Newt::Label.new(-1, -1, _("URL:"))
+  e_url = Newt::Entry.new(-1, -1, "", 45, 0)
+  form_grid.set_field(0, 0, Newt::GRID_COMPONENT, l_url, 0, 0, 2, 1, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(1, 0, Newt::GRID_COMPONENT, e_url, 0, 0, 2, 1, Newt::ANCHOR_LEFT, 0)
+
+  top_grid.set_field(0, 0, Newt::GRID_COMPONENT, t_desc, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
+  top_grid.set_field(0, 1, Newt::GRID_SUBGRID, form_grid, 0, 0, 0, 0, 0, 0)
+  top_grid.set_field(0, 2, Newt::GRID_SUBGRID, but_grid, 0, 0, 0, 0, 0, 0)
+
+  top_grid.wrapped_window(_("Image transfer - http(s)"))
+
+  f = Newt::Form.new
+  f.add(t_desc)
+  f.add(l_url, e_url)
+  f.add(b_start, b_cancel)
+  answer = f.run
+  if answer == b_start
+    cmd = "curl -k #{e_url.get} | #{pipeline.data.uncompress_cmd} > #{pipeline.data.volume}"
+    action = Proc.new do
+      begin
+        command(cmd, true, true, false, false)
+        result = ($? == 0)
+        command("shutdown -r now 'Reboot after image transfer'") if pipeline.data.reboot
+        result
+      end
+    end
+    pipeline.append :screen_info
+    pipeline.append :screen_welcome
+    pipeline.data.action_proc = action
+    pipeline.data.message = _("Work in progress, use tty2 for more details...")
+    pipeline.data.error_message = _("Unable to transfer image, investigate logs.")
+  else
+    pipeline.cancel :screen_image_mode
+  end
+end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_mode.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_mode.rb
@@ -1,0 +1,57 @@
+def screen_image_mode pipeline
+  b_next = Newt::Button.new(-1, -1, _("Next"))
+  b_cancel = Newt::Button.new(-1, -1, _("Cancel"))
+
+  width = 50
+  t_desc = Newt::Textbox.new(-1, -1, width, 4, Newt::FLAG_WRAP)
+  t_desc.set_text _("Select udpcast multicast tool (EXPERIMENTAL) or simple HTTP download to download or upload an image.")
+
+  top_grid = Newt::Grid.new(1, 3)
+  form_grid = Newt::Grid.new(1, 6)
+  but_grid = Newt::Grid.new(3, 1)
+
+  # set_field(column, row, type, value, pad_left, pad_top, pad_right, pad_bottom, anchor, flags)
+  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_next, 1, 0, 1, 0, 0, 0)
+  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_cancel, 1, 0, 1, 0, 0, 0)
+
+  r_udpreciever = Newt::RadioButton.new(-1, -1, _("UDP reciever"), 1, nil)
+  r_udpsender = Newt::RadioButton.new(-1, -1, _("UDP sender"), 0, r_udpreciever)
+  r_http = Newt::RadioButton.new(-1, -1, _("HTTP(S) download"), 0, r_udpsender)
+  ch_reboot = Newt::Checkbox.new(-1, -1, _("Reboot when done"), "*", " *")
+  l_volume = Newt::Label.new(-1, -1, _("Target or source volume:"))
+  e_volume = Newt::Entry.new(-1, -1, "/dev/null", 20, Newt::FLAG_SCROLL)
+
+  form_grid.set_field(0, 0, Newt::GRID_COMPONENT, r_udpreciever, 0, 0, 1, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 1, Newt::GRID_COMPONENT, r_udpsender, 0, 0, 0, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 2, Newt::GRID_COMPONENT, r_http, 0, 0, 0, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 3, Newt::GRID_COMPONENT, ch_reboot, 0, 1, 0, 1, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 4, Newt::GRID_COMPONENT, l_volume, 0, 0, 0, 0, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 5, Newt::GRID_COMPONENT, e_volume, 0, 0, 0, 1, Newt::ANCHOR_LEFT, 0)
+
+  top_grid.set_field(0, 0, Newt::GRID_COMPONENT, t_desc, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
+  top_grid.set_field(0, 1, Newt::GRID_SUBGRID, form_grid, 0, 0, 0, 0, 0, 0)
+  top_grid.set_field(0, 2, Newt::GRID_SUBGRID, but_grid, 0, 0, 0, 0, 0, 0)
+
+  top_grid.wrapped_window(_("Image transfer - mode"))
+
+  f = Newt::Form.new
+  f.add(t_desc, r_udpreciever, r_udpsender, r_http, ch_reboot, l_volume, e_volume)
+  f.add(b_next, b_cancel)
+  answer = f.run
+  if answer == b_next && ((r_udpsender.get == '*' && !File.exist?("/usr/sbin/udp-sender")) || (r_udpreciever.get == '*' && !File.exist?("/usr/sbin/udp-receiver")))
+    Newt::Screen.win_message(_("Missing feature"), _("Try again"), _("UDP cast utility not available in this build"))
+    pipeline.append :screen_image_mode
+  elsif answer == b_next
+    pipeline.append :screen_image_compress
+    pipeline.data.volume = e_volume.get
+    pipeline.data.reboot = (ch_reboot.get == '*')
+    if r_http.get == '*'
+      pipeline.append :screen_image_http
+    else
+      pipeline.data.udpcast = (r_udpsender.get == '*') ? "sender" : "reciever"
+      pipeline.append :screen_image_udpcast
+    end
+  else
+    pipeline.cancel
+  end
+end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_udpcast.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/image_udpcast.rb
@@ -1,0 +1,64 @@
+def screen_image_udpcast pipeline
+  b_start = Newt::Button.new(-1, -1, _("Start"))
+  b_cancel = Newt::Button.new(-1, -1, _("Cancel"))
+
+  width = 50
+  t_desc = Newt::Textbox.new(-1, -1, width, 4, Newt::FLAG_WRAP)
+  t_desc.set_text _("Use port range 9000-9100 or change firewall configuration. Switch to console 2 (ALT+F2) or use journalctl to watch progress.")
+
+  top_grid = Newt::Grid.new(1, 3)
+  form_grid = Newt::Grid.new(2, 2)
+  but_grid = Newt::Grid.new(2, 1)
+
+  # set_field(column, row, type, value, pad_left, pad_top, pad_right, pad_bottom, anchor, flags)
+  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_start, 1, 0, 1, 0, 0, 0)
+  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_cancel, 1, 0, 1, 0, 0, 0)
+
+  l_port = Newt::Label.new(-1, -1, _("Port (N, N+1):"))
+  e_port = Newt::Entry.new(-1, -1, "9000", 10, 0)
+  l_extra = Newt::Label.new(-1, -1, _("Extra options:"))
+  e_extra = Newt::Entry.new(-1, -1, "", 30, Newt::FLAG_SCROLL)
+  form_grid.set_field(0, 0, Newt::GRID_COMPONENT, l_port, 0, 0, 2, 1, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(1, 0, Newt::GRID_COMPONENT, e_port, 0, 0, 2, 1, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(0, 1, Newt::GRID_COMPONENT, l_extra, 0, 0, 2, 1, Newt::ANCHOR_LEFT, 0)
+  form_grid.set_field(1, 1, Newt::GRID_COMPONENT, e_extra, 0, 0, 2, 1, Newt::ANCHOR_LEFT, 0)
+
+  top_grid.set_field(0, 0, Newt::GRID_COMPONENT, t_desc, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
+  top_grid.set_field(0, 1, Newt::GRID_SUBGRID, form_grid, 0, 0, 0, 0, 0, 0)
+  top_grid.set_field(0, 2, Newt::GRID_SUBGRID, but_grid, 0, 0, 0, 0, 0, 0)
+
+  top_grid.wrapped_window(_("Image transfer - udpcast"))
+
+  f = Newt::Form.new
+  f.add(t_desc)
+  f.add(l_port, e_port)
+  f.add(l_extra, e_extra)
+  f.add(b_start, b_cancel)
+  answer = f.run
+  if answer == b_start
+    log_file = "/tmp/udpcast.log"
+    File.delete(log_file) if File.exists?(log_file)
+    if pipeline.data.udpcast == "receiver"
+      cmd = "udp-receiver --interface #{pipeline.data.primary_name} --portbase #{e_port.get} --nokbd #{e_extra.get} --log #{log_file} | #{pipeline.data.uncompress_cmd} > #{pipeline.data.volume}"
+    else
+      cmd = "cat #{pipeline.data.volume} | #{pipeline.data.compress_cmd} | udp-sender --interface #{pipeline.data.primary_name} --portbase #{e_port.get} --nokbd #{e_extra.get} --log #{log_file}"
+    end
+    action = Proc.new do
+      begin
+        command(cmd, true, true, false, false)
+        result = ($? == 0)
+        command("shutdown -r now 'Reboot after image transfer'") if pipeline.data.reboot
+        result
+      ensure
+        command("systemd-cat -t udpcast < #{log_file}", false, false, false, false) if File.exists?(log_file)
+      end
+    end
+    pipeline.append :screen_info
+    pipeline.append :screen_welcome
+    pipeline.data.action_proc = action
+    pipeline.data.message = _("Work in progress, use tty2 for more details...")
+    pipeline.data.error_message = _("Unable to transfer image, investigate logs.")
+  else
+    pipeline.cancel :screen_image_mode
+  end
+end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/info.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/info.rb
@@ -1,5 +1,5 @@
-def screen_info action_proc, message, error_message, success_screen, failure_screen
-  text_help, tw, th = Newt.reflow_text(message, 60, 5, 5)
+def screen_info pipeline
+  text_help, tw, th = Newt.reflow_text(pipeline.data.message, 60, 5, 5)
   t = Newt::Textbox.new(-1, -1, tw, th, Newt::FLAG_WRAP)
   t.set_text(text_help)
 
@@ -13,13 +13,13 @@ def screen_info action_proc, message, error_message, success_screen, failure_scr
 
   # facter sometimes leaves messages on stdout, refresh before/after
   Newt::Screen.refresh
-  result = action_proc.call
+  result = pipeline.data.action_proc.call
   Newt::Screen.refresh
 
   if result
-    success_screen
+    0
   else
-    Newt::Screen.win_message(_("Operation failed"), _("OK"), error_message)
-    failure_screen
+    Newt::Screen.win_message(_("Operation failed"), _("OK"), pipeline.data.error_message)
+    1
   end
 end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/primary_iface.rb
@@ -1,17 +1,20 @@
-def screen_primary_iface dhcp = false
+def screen_primary_iface pipeline
+  raise "Primary interface selection requires a sucessive screen" if pipeline.size < 1
   bootif = normalize_mac(cmdline('BOOTIF'))
   preselectedif = normalize_mac(cmdline('fdi.pxmac'))
   vlanid = cmdline('fdi.vlan.primary', '')
 
   width = 60
   t_desc = Newt::Textbox.new(-1, -1, width, 3, Newt::FLAG_WRAP)
-  t_desc.set_text _("Select primary (provisioning) network interface with connection to server or proxy:")
+  t_desc.set_text(pipeline.data.message || _("Select primary (provisioning) network interface with connection to server or proxy:"))
   lb_ifaces = Newt::Listbox.new(-1, -1, 7, Newt::FLAG_SCROLL)
-  l_vlan = Newt::Label.new(-1, -1, "VLAN ID:")
-  t_vlan = Newt::Entry.new(-1, -1, vlanid, 10, Newt::FLAG_SCROLL)
-  b_select = Newt::Button.new(-1, -1, _("Select"))
+  l_vlan = Newt::Label.new(-1, -1, "VLAN ID: ")
+  t_vlan = Newt::Entry.new(-1, -1, vlanid, 4, 0)
+  b_ok_dhcp = Newt::Button.new(-1, -1, _("DHCP"))
+  b_ok_manual = Newt::Button.new(-1, -1, _("Manual"))
   b_cancel = Newt::Button.new(-1, -1, _("Cancel"))
   lb_ifaces.set_width(width)
+  names = {}
 
   log_msg "Building net interfaces TUI (bootif=#{bootif})"
   ix = 0
@@ -25,46 +28,55 @@ def screen_primary_iface dhcp = false
     preselected = (mac == preselectedif)
     log_msg "Device #{name} #{mac} link=#{link} booted=#{booted}"
     lb_ifaces.append "#{mac} #{name} #{' (link up)' if link} #{' (pxebooted)' if booted}", mac
+    names[mac] = name
     lb_ifaces.set_current ix if booted || preselected
     ix = ix + 1
   end
 
-  main_grid = Newt::Grid.new(1, 4)
-  but_grid = Newt::Grid.new(2, 1)
+  main_grid = Newt::Grid.new(1, 3)
+  but_grid = Newt::Grid.new(4, 1)
   vlan_grid = Newt::Grid.new(2, 1)
-
-  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_select, 0, 0, 0, 0, 0, 0)
-  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_cancel, 0, 0, 0, 0, 0, 0)
 
   vlan_grid.set_field(0, 0, Newt::GRID_COMPONENT, l_vlan, 0, 0, 0, 0, 0, 0)
   vlan_grid.set_field(1, 0, Newt::GRID_COMPONENT, t_vlan, 0, 0, 0, 0, 0, 0)
 
+  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_ok_dhcp, 0, 0, 0, 0, 0, 0)
+  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_ok_manual, 0, 0, 0, 0, 0, 0)
+  but_grid.set_field(2, 0, Newt::GRID_COMPONENT, b_cancel, 0, 0, 0, 0, 0, 0)
+  but_grid.set_field(3, 0, Newt::GRID_SUBGRID, vlan_grid, 0, 0, 0, 0, 0, 0)
+
   main_grid.set_field(0, 0, Newt::GRID_COMPONENT, t_desc, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
   main_grid.set_field(0, 1, Newt::GRID_COMPONENT, lb_ifaces, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
-  main_grid.set_field(0, 2, Newt::GRID_SUBGRID, vlan_grid, 0, 1, 0, 0, 0, 0)
-  main_grid.set_field(0, 3, Newt::GRID_SUBGRID, but_grid, 0, 1, 0, 0, 0, Newt::GRID_FLAG_GROWX)
-  main_grid.wrapped_window(_("Primary interface"))
+  main_grid.set_field(0, 2, Newt::GRID_SUBGRID, but_grid, 0, 1, 0, 0, 0, Newt::GRID_FLAG_GROWX)
+  main_grid.wrapped_window(pipeline.data.title || _("Primary interface"))
 
   f = Newt::Form.new
   if preselectedif
-    f.add(b_select, b_cancel, t_desc, lb_ifaces, l_vlan, t_vlan)
+    f.add(b_ok_dhcp, b_ok_manual, b_cancel, l_vlan, t_vlan, t_desc, lb_ifaces)
   else
-    f.add(t_desc, lb_ifaces, l_vlan, t_vlan, b_select, b_cancel)
+    f.add(t_desc, lb_ifaces, b_ok_dhcp, b_ok_manual, b_cancel, l_vlan, t_vlan)
   end
   answer = f.run()
-  if answer == b_select
-    primary_mac = lb_ifaces.get_current_as_string
-    vlan_id = t_vlan.get
-    if dhcp
-      action = Proc.new { configure_network false, primary_mac, nil, nil, nil, vlan_id }
-      [:screen_info, action, _("Configuring network via DHCP. This operation can take several minutes to complete."), _("Unable to bring network via DHCP"),
-        [:screen_foreman, primary_mac, nil, cmdline('proxy.url'), cmdline('proxy.type')],
-        [:screen_network, primary_mac, vlan_id]]
-    else
-      detect_ip, detect_gw, detect_dns = detect_ipv4_credentials('primary')
-      [:screen_network, primary_mac, vlan_id, cmdline('fdi.pxip', detect_ip), cmdline('fdi.pxgw', detect_gw), cmdline('fdi.pxdns', detect_dns)]
-    end
-  elsif answer == b_cancel
-    :screen_welcome
+  if answer == b_cancel
+    pipeline.cancel pipeline.data.on_cancel
+    return
+  end
+  pipeline.data.primary_mac = lb_ifaces.get_current_as_string
+  pipeline.data.primary_name = names[pipeline.data.primary_mac]
+  pipeline.data.vlan_id = t_vlan.get
+  if answer == b_ok_dhcp
+    # the screen after will be picked depedning on the return value of the next screen (0 or 1)
+    pipeline.append [pipeline.next, :screen_primary_iface]
+    # and set the very next screen
+    pipeline.prepend :screen_info
+    pipeline.data.action_proc = Proc.new { configure_network false, pipeline.data.primary_mac, nil, nil, nil, pipeline.data.vlan_id }
+    pipeline.data.message = _("Configuring network via DHCP. This operation can take several minutes to complete.")
+    pipeline.data.error_message = _("Unable to bring network via DHCP")
+  else # manual
+    detect_ip, detect_gw, detect_dns = detect_ipv4_credentials('primary')
+    pipeline.prepend :screen_network
+    pipeline.data.manual_ip = cmdline('fdi.pxip', detect_ip)
+    pipeline.data.manual_gw = cmdline('fdi.pxgw', detect_gw)
+    pipeline.data.manual_dns = cmdline('fdi.pxdns', detect_dns)
   end
 end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/ssh.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/ssh.rb
@@ -1,4 +1,4 @@
-def screen_ssh
+def screen_ssh pipeline
   t_desc = Newt::Textbox.new(-1, -1, 39, 3, Newt::FLAG_WRAP)
   t_desc.set_text _("Enter root password to unlock the account and enable SSH service:")
   e_password = Newt::Entry.new(-1, -1, "", 39, Newt::FLAG_PASSWORD)
@@ -26,7 +26,8 @@ def screen_ssh
   elsif answer == b_disable
     command("systemctl stop sshd.service")
   elsif answer == b_cancel
-    :screen_welcome
+    pipeline.cancel pipeline.data.on_cancel
   end
-  :screen_status
+  # TODO this screen could require next enqued one
+  pipeline.append :screen_status
 end

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/status.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/status.rb
@@ -1,4 +1,7 @@
-def generate_info extra_status = '', server = discover_server, proxy_type = proxy_type
+def generate_info extra_status = '', server = nil, type = nil
+  return "N/A" if ENV['FDI_DEVEL']
+  server ||= discover_server
+  type ||= proxy_type
   status = _("N/A") + ' (' + _("use Status to update") + ')'
   response = _("N/A")
   if File.exist?(f = '/tmp/discovery-http-success')
@@ -18,7 +21,7 @@ def generate_info extra_status = '', server = discover_server, proxy_type = prox
 #{_('Primary IPv4')}: #{get_ipv4}
 
 #{_('Discovery server')}: #{discover_server || 'N/A'}
-#{_('Endpoint type')}: #{proxy_type}
+#{_('Endpoint type')}: #{type}
 
 #{_('Latest server response')}:
 #{response}
@@ -28,20 +31,21 @@ def generate_info extra_status = '', server = discover_server, proxy_type = prox
 EOS
 end
 
-def screen_status status = generate_info, active_button = 0
+def screen_status pipeline
   t_status = Newt::Textbox.new(-1, -1, 70, 16, Newt::FLAG_SCROLL)
-  t_status.set_text(status)
+  t_status.set_text(pipeline.data.status_text || generate_info)
 
   buttons = []
   buttons[0] = b_resend = Newt::CompactButton.new(-1, -1, _("Resend"))
   buttons[1] = b_status = Newt::CompactButton.new(-1, -1, _("Status"))
   buttons[2] = b_facts = Newt::CompactButton.new(-1, -1, _("Facts"))
-  buttons[3] = b_syslog = Newt::CompactButton.new(-1, -1, _("Logs"))
-  buttons[4] = b_ssh = Newt::CompactButton.new(-1, -1, _("SSH"))
-  buttons[5] = b_reboot = Newt::CompactButton.new(-1, -1, _("Reboot"))
+  buttons[3] = b_image = Newt::CompactButton.new(-1, -1, _("Image"))
+  buttons[4] = b_syslog = Newt::CompactButton.new(-1, -1, _("Logs"))
+  buttons[5] = b_ssh = Newt::CompactButton.new(-1, -1, _("SSH"))
+  buttons[6] = b_reboot = Newt::CompactButton.new(-1, -1, _("Reboot"))
 
   main_grid = Newt::Grid.new(1, 2)
-  but_grid = Newt::Grid.new(6, 1)
+  but_grid = Newt::Grid.new(7, 1)
 
   buttons.each_with_index do |btn, i|
     but_grid.set_field(i, 0, Newt::GRID_COMPONENT, btn, 0, 0, 0, 0, 0, 0)
@@ -52,7 +56,7 @@ def screen_status status = generate_info, active_button = 0
   main_grid.wrapped_window(_("Discovery status"))
 
   f = Newt::Form.new
-  f.add(t_status, b_resend, b_status, b_facts, b_syslog, b_ssh, b_reboot)
+  f.add(t_status, b_resend, b_status, b_facts, b_image, b_syslog, b_ssh, b_reboot)
   answer = f.run()
   if answer == b_status
     :screen_status
@@ -64,6 +68,8 @@ def screen_status status = generate_info, active_button = 0
     [:screen_status, command("shutdown -r now Reboot from TUI")]
   elsif answer == b_ssh
     :screen_ssh
+  elsif answer == b_image
+    [:screen_primary_iface, false, :screen_image, :screen_status, _("Transfer interface"), message = _("Select interface for udpcast image transfer:")]
   elsif answer == b_resend
     if cmdline('BOOTIF')
       command("rm -f /tmp/discovery-http*")

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/screen/welcome.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/screen/welcome.rb
@@ -1,29 +1,41 @@
-def screen_welcome
-  text_help, tw, th = Newt.reflow_text(_('Select Manual network setup to select primary interface, configure network (no DHCP required), setup server credentials, add custom facts and trigger auto-provisioning via Discovery rules. This will lead to kernel reload (kexec) into installer. Select Discover with DHCP to select primary interface and proceed with DHCP configuration and standard discovery without any custom facts. This will reboot the host once the system is provisioned either manually or via Discovery rules.'), 60, 5, 5)
+def screen_welcome pipeline
+  text_help, tw, th = Newt.reflow_text(_('Select Manual to select primary interface, configure network (no DHCP required), setup server credentials, add custom facts and trigger auto-provisioning via Discovery rules. This will lead to kernel reload (kexec) into installer. Select DHCP to select primary interface and proceed with DHCP configuration and standard discovery without any custom facts. This will reboot the host once the system is provisioned either manually or via Discovery rules.'), 60, 5, 5)
   t_welcome = Newt::Textbox.new(-1, -1, tw, th, Newt::FLAG_WRAP)
   t_welcome.set_text(text_help)
 
-  b_proceed = Newt::Button.new(-1, -1, _("Manual network setup"))
-  b_discover = Newt::Button.new(-1, -1, _("Discover with DHCP"))
+  b_discover = Newt::Button.new(-1, -1, _("Discover node"))
+  b_image = Newt::Button.new(-1, -1, _("Image transfer"))
+  b_status = Newt::Button.new(-1, -1, _("Status screen"))
 
   main_grid = Newt::Grid.new(1, 2)
-  but_grid = Newt::Grid.new(2, 1)
+  but_grid = Newt::Grid.new(3, 1)
 
-  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_proceed, 0, 0, 0, 0, 0, 0)
-  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_discover, 0, 0, 0, 0, 0, 0)
+  but_grid.set_field(0, 0, Newt::GRID_COMPONENT, b_discover, 0, 0, 0, 0, 0, 0)
+  but_grid.set_field(1, 0, Newt::GRID_COMPONENT, b_image, 0, 0, 0, 0, 0, 0)
+  but_grid.set_field(2, 0, Newt::GRID_COMPONENT, b_status, 0, 0, 0, 0, 0, 0)
 
   main_grid.set_field(0, 0, Newt::GRID_COMPONENT, t_welcome, 0, 0, 0, 1, 0, 0)
   main_grid.set_field(0, 1, Newt::GRID_SUBGRID, but_grid, 0, 0, 0, 0, 0, Newt::GRID_FLAG_GROWX)
-  main_grid.wrapped_window(_("Manual/PXE-less provisioning workflow"))
+  main_grid.wrapped_window(_("Welcome to PXE-less provisioning"))
 
   f = Newt::Form.new
-  f.add(t_welcome, b_proceed, b_discover)
+  f.add(t_welcome, b_discover, b_image, b_status)
   answer = f.run()
-  if answer == b_discover
-    [:screen_primary_iface, true]
-  elsif answer == b_proceed
-    :screen_primary_iface
+  if answer == b_status
+    pipeline.append :screen_status
+    pipeline.data.status_text = generate_info(_('PXE-less mode'))
+  elsif answer == b_image
+    pipeline.append :screen_primary_iface
+    pipeline.append :screen_image_mode
+    pipeline.data.title = _("Transfer interface")
+    pipeline.data.message = _("Select primary (provisioning) network interface with connection to server or proxy:")
+    pipeline.data.on_ok = :screen_image
+    pipeline.data.on_cancel = :screen_welcome
+  elsif answer == b_discover
+    pipeline.append :screen_primary_iface
+    pipeline.append :screen_foreman
+    pipeline.data.dhcp = false
   else
-    :quit
+    pipeline.append :quit
   end
 end


### PR DESCRIPTION
Previously, FDI TUI was just a simple screen (status), then few more were added, then PXE less, DHCP mode and today there are multiple paths. The TUI code is clunky, this introduces "pipeline" hash that is shared across all screens and allows arbitrary screen switching. In short, previously one screen only could switch to different screen and there were extra options when to decide 2nd and other screens. Now with pipeline instance, it is possible to "schedule" arbitrary amount of screens (whole workflow) in advance which is much more clean.

Also this adds new UDP Cast screen which is a simple UI for udpcast utility. This is nice tool that can be used for recieveing images and deploying them onto bare-metal boxes. Utility can be also used from command line if UI is not powerful enough. We can also integrate ReX with udpcast and voilla - nice new feature - auto image-based deployment via ReX or ad-hoc from TUI.