### PR TITLE
Fixes #18715 - support for fdi.script option

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -25,6 +25,7 @@ facter
 ethtool
 net-tools
 dmidecode
+bind-utils
 virt-what
 
 # Foreman proxy

--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -39,6 +39,8 @@ systemctl enable foreman-proxy.service
 systemctl enable discovery-fetch-extensions.path
 systemctl enable discovery-start-extensions.service
 systemctl enable discovery-menu.service
+systemctl enable discovery-script-pxe.service
+systemctl enable discovery-script-pxeless.service
 
 # register service is started manually from discovery-menu
 systemctl disable discovery-register.service
@@ -106,7 +108,7 @@ echo " * setting up journald and ttys"
 systemctl disable getty@tty1.service getty@tty2.service
 systemctl mask getty@tty1.service getty@tty2.service
 echo "Storage=volatile" >> /etc/systemd/journald.conf
-echo "RuntimeMaxUse=15M" >> /etc/systemd/journald.conf
+echo "RuntimeMaxUse=25M" >> /etc/systemd/journald.conf
 echo "ForwardToSyslog=no" >> /etc/systemd/journald.conf
 echo "ForwardToConsole=no" >> /etc/systemd/journald.conf
 systemctl enable journalctl.service

--- a/README.md
+++ b/README.md
@@ -81,11 +81,21 @@ http://theforeman.org/plugins/foreman_discovery/
 Building
 --------
 
+A host with either Fedora or CentOS 7 is required. RHEL 7 cannot be used as
+it is missing core dependency (livecd-tools), but this can be workarounded
+by installing it from CentOS 7 repositories (and two dependencies). Grub2
+EFI and Shim packages are only required if the resulting ISO must boot on
+UEFI systems.
+
 Install the required packages:
 
 ```
-$ sudo yum install livecd-tools pykickstart isomd5sum
+$ sudo yum install livecd-tools pykickstart isomd5sum syslinux \
+  grub2-efi shim grub2-efi-x64 grub2-efi-x64-cdboot shim-x64
 ```
+
+On older versions of Fedora or RHEL 7.0-7.3 shim and grub packages has no
+x64 suffix, the command above will install one of the two.
 
 To prepare CentOS 7 kickstart do:
 
@@ -99,7 +109,7 @@ To prepare Fedora 19 kickstart do:
 $ ./build-livecd fdi-fedora19.ks
 ```
 
-To build the image (make sure you have at least 1 GB free space in /tmp):
+To build the image (make sure you have at least 3 GB free space in /tmp):
 
 ```
 $ sudo ./build-livecd-root

--- a/aux/basescript-examples/README
+++ b/aux/basescript-examples/README
@@ -1,0 +1,12 @@
+Example scripts which can be run from kernel commandline. To encode them do:
+
+# cat aux/basescript-examples/myscript | gzip -9 | base64 -w0
+fdi.script=H4sIAK4hZ1oCA0tNzshXUA/JyCxWAKJEhZLU4hJ1LgA92U9qFgAAAA==
+
+And append. Keep in mind that kernel command line length is very limited.
+
+There are couple of helper shell functions which can be used defined in:
+
+  root/usr/bin/discovery-script
+
+Send patches with more functions for more options.

--- a/aux/basescript-examples/configure-bond.sh
+++ b/aux/basescript-examples/configure-bond.sh
@@ -1,0 +1,8 @@
+no_tui
+fact via_script 1
+clean_nm
+cfg_bond bond0
+for DEV in eth0 eth1; do cfg_slave bond0 $DEV; done
+reload_nm
+sleep 30
+discover_now

--- a/aux/discovery-script-creator
+++ b/aux/discovery-script-creator
@@ -1,0 +1,10 @@
+#!/bin/bash
+SCRIPT="fdi.script=$(cat - | gzip -9 | base64 -w0)"
+LENGTH=${#SCRIPT}
+MAX=310
+echo $SCRIPT
+echo "Maximum length: $MAX (512 limit - current options)"
+echo "Actual length: $LENGTH"
+if [[ $LENGTH -gt $MAX ]]; then
+  echo "Consider shell minifier or stage2 script downloaded from network."
+fi

--- a/aux/vagrant-build/Vagrantfile
+++ b/aux/vagrant-build/Vagrantfile
@@ -4,13 +4,10 @@ boxes = [
   {:name => 'precise',  :libvirt => 'fm-ubuntu1204', :image_name => /Ubuntu.*12\.04/, :os_user => 'ubuntu'},
   {:name => 'squeeze',  :libvirt => 'fm-debian6',    :image_name => /Debian.*6/,      :os_user => 'debian'},
   {:name => 'wheezy',   :libvirt => 'fm-debian7',    :image_name => /Debian.*7/,      :os_user => 'debian'},
-  {:name => 'f24',      :libvirt => 'fm-fedora24',   :image_name => /Fedora.*24.*PVHVM/, :pty => true},
-  {:name => 'f25',      :libvirt => 'fm-fedora25',   :image_name => /Fedora.*25.*PVHVM/, :pty => true},
-  {:name => 'f26',      :libvirt => 'fm-fedora25',   :image_name => /Fedora.*26.*PVHVM/, :pty => true},
   {:name => 'f27',      :libvirt => 'fm-fedora25',   :image_name => /Fedora.*27.*PVHVM/, :pty => true},
   {:name => 'f28',      :libvirt => 'fm-fedora25',   :image_name => /Fedora.*28.*PVHVM/, :pty => true},
   {:name => 'el6',      :libvirt => 'fm-centos64',   :image_name => /CentOS 6\.5 SELinux/, :default => true, :pty => true},
-  # There is no livecd-tools available in EPEL7 therefore we build on Fedora rather than CentOS7
+  # There is no livecd-tools available in EL 7.0-7.3 - use Fedora instead
   {:name => 'el7',      :libvirt => 'fm-centos70',   :image_name => /CentOS 7/, :default => true, :pty => true},
 ]
 

--- a/aux/vagrant-build/build_image.sh
+++ b/aux/vagrant-build/build_image.sh
@@ -7,9 +7,11 @@ export proxy_repo=${3:-nightly}
 NAME=foreman-discovery-image
 
 # give the VM some time to finish booting and network configuration
-ping -c1 8.8.8.8 2>&1 >/dev/null && echo OK || echo FAIL
+sleep 30
+ping -c1 8.8.8.8 2>&1 >/dev/null && echo NET OK || echo NET FAILURE
 yum -y install livecd-tools appliance-tools-minimizer \
-  hardlink git wget pykickstart isomd5sum
+  hardlink git wget pykickstart isomd5sum syslinux
+yum -y install grub2-efi shim || yum -y install grub2-efi-x64 grub2-efi-x64-cdboot shim-x64 || true
 
 # build plugin
 pushd /root

--- a/root/etc/systemd/system/discovery-script-pxe.service
+++ b/root/etc/systemd/system/discovery-script-pxe.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Script PXE
+Wants=basic.target
+After=foreman-proxy.service NetworkManager.service
+ConditionKernelCommandLine=BOOTIF
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/default/discovery
+RemainAfterExit=yes
+ExecStart=/usr/bin/discovery-script
+
+[Install]
+WantedBy=multi-user.target

--- a/root/etc/systemd/system/discovery-script-pxeless.service
+++ b/root/etc/systemd/system/discovery-script-pxeless.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Script PXE-less
+Wants=basic.target
+Before=foreman-proxy.service NetworkManager.service
+After=nm-prepare.service systemd-journald.service
+ConditionKernelCommandLine=!BOOTIF
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/default/discovery
+RemainAfterExit=yes
+ExecStart=/usr/bin/discovery-script
+
+[Install]
+WantedBy=multi-user.target

--- a/root/usr/bin/discovery-menu
+++ b/root/usr/bin/discovery-menu
@@ -1,5 +1,8 @@
 #!/usr/bin/ruby
 
+exit(0) if File.exist?('/tmp/disable-menu')
+
+
 require 'discovery/menu'
 require 'discovery/screen/countdown'
 require 'discovery/screen/facts'

--- a/root/usr/bin/discovery-script
+++ b/root/usr/bin/discovery-script
@@ -1,0 +1,11 @@
+#!/bin/bash
+source /etc/default/discovery
+source /usr/share/fdi/commonfunc.sh
+exportKCL
+[ -d /tmp/facts ] || mkdir /tmp/facts
+defaultscript=${KCL_FDI_SCRIPT:-H4sIAOj1ZloCA0tNzshXUPLLVyhOLsosKFEoSCwuTk1R4gIAIbwTwhgAAAA=}
+basescript=${1:-$defaultscript}
+cat /usr/share/fdi/script-helpers.sh > /tmp/discovery-script
+echo "$basescript" | base64 -d | gunzip >> /tmp/discovery-script
+[[ $? -eq 0 ]] && ( bash /tmp/discovery-script | tee /tmp/discovery-script.log )
+rm /tmp/discovery-script

--- a/root/usr/share/fdi/facts/discovery-facts.rb
+++ b/root/usr/share/fdi/facts/discovery-facts.rb
@@ -212,3 +212,12 @@ Facter.add("nmprimary_ptr") do
     end
   end
 end
+
+# Keep this as the last one - overrides from file system
+Dir.glob('/tmp/facts/*') do |file|
+  Facter.add(File.basename(file)) do
+    setcode do
+      File.open(file) {|f| f.readline.chomp}
+    end
+  end
+end

--- a/root/usr/share/fdi/script-helpers.sh
+++ b/root/usr/share/fdi/script-helpers.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+source /etc/default/discovery
+source /usr/share/fdi/commonfunc.sh
+exportKCL
+
+# helper functions
+clean_nm() {
+  rm -f /etc/NetworkManager/system-connections/*
+}
+
+no_tui() {
+  touch /tmp/disable-menu
+}
+
+reload_nm() {
+  # in PXE-less mode NM is not yet started - this will fail
+  nmcli connection reload 2>/dev/null || true
+}
+
+discover_now() {
+  nohup /usr/bin/discovery-register &> /tmp/discovery-script-register.log &
+}
+
+enable_discovery() {
+  systemctl enable discovery-register
+}
+
+hwaddr() {
+  HWADDR=$(cat /sys/class/net/$1/address)
+}
+
+cfg_eth() {
+  NAME=${1:-eth0}
+  cat >/etc/sysconfig/network-scripts/ifcfg-$NAME <<EOF
+TYPE=Ethernet
+NAME=$DEV
+DEVICE=$DEV
+ONBOOT=yes
+$2
+$3
+$4
+$5
+$6
+$7
+$8
+$9
+EOF
+}
+
+cfg_bond() {
+  NAME=${1:-bond0}
+  OPTS=${2:-miimon=100 mode=balance-rr}
+  cat >/etc/sysconfig/network-scripts/ifcfg-$NAME <<EOF
+TYPE=Bond
+ONBOOT=yes
+DEVICE=$NAME
+BONDING_MASTER=yes
+BONDING_OPTS="$OPTS"
+BOOTPROTO=dhcp
+DEFROUTE=yes
+IPV6INIT=no
+NAME=$NAME
+$3
+$4
+$5
+$6
+$7
+$8
+$9
+EOF
+}
+
+cfg_slave() {
+  MASTER=${1:-bond0}
+  DEV=${2:-eth0}
+  cat >/etc/sysconfig/network-scripts/ifcfg-slave-$DEV <<EOF
+TYPE=Ethernet
+NAME=slave-$DEV
+DEVICE=$DEV
+ONBOOT=yes
+MASTER=$MASTER
+SLAVE=yes
+$3
+$4
+$5
+$6
+$7
+$8
+$9
+EOF
+}
+
+fact() {
+  echo "$2" > "/tmp/facts/$1"
+}
+
+set +x


### PR DESCRIPTION
New `fdi.script` option is added, it requies base64-encoded gzipped script which is executed during boot. In PXE-less mode (when BOOTIF is not present on kernel commandline) it is executed before NetworkManager is started, in PXE mode it is executed after NetworkManager finished configuration and IP is assigned.

To generate compatible string use:

    echo "echo 'This is a test'" | gzip -9 | base64 -w0
    H4sIAK4hZ1oCA0tNzshXUA/JyCxWAKJEhZLU4hJ1LgA92U9qFgAAAA==

and then append the option to kernel command line. See system journal for output (grep for `discovery-script`).

    APPEND ... fdi.script=H4sIAK4hZ1oCA0tNzshXUA/JyCxWAKJEhZLU4hJ1LgA92U9qFgAAAA==
