### PR TITLE
Fixes #22628 - fdi.dhcp_sendhost=true option added

### DIFF
--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -6,7 +6,10 @@ bootif="$(normalizeHwAddr "${BOOTMAC}")"
 mac=${2:-$bootif}
 uuid=$(/usr/bin/uuid)
 timeout=${KCL_FDI_DHCP_TIMEOUT:-300}
+sendhost=${KCL_FDI_DHCP_SENDHOST:-false}
 ctype="802-3-ethernet"
+
+[[ "$sendhost" == "false" ]] || sendhost=true
 
 deploy_config() {
   chown root:root $1
@@ -50,6 +53,7 @@ method=manual
 address1=$ip
 gateway=$gw
 dns=$dns;
+dhcp-send-hostname=$sendhost
 [ipv6]
 method=ignore
 [vlan]
@@ -71,7 +75,7 @@ autoconnect-priority=1
 mac-address=$mac
 [ipv4]
 method=auto
-dhcp-send-hostname=false
+dhcp-send-hostname=$sendhost
 dhcp-timeout=$timeout
 [ipv6]
 method=ignore
@@ -97,7 +101,7 @@ dhcp-timeout=$timeout
 ignore-auto-dns=true
 ignore-auto-routes=true
 never-default=true
-dhcp-send-hostname=false
+dhcp-send-hostname=$sendhost
 [ipv6]
 method=ignore
 EONS


### PR DESCRIPTION
Our consulting stumbled upon a DHCP server which requires DHCP request to have the "hostname" option, otherwise lease is not created. This adds hew option `fdi.dhcp_sendhost` which can be true or false which is added into networkmanager configuration. By default hostname is NOT set to prevent from multiple lease creation.