### PR TITLE
Use small cracklib dictionary

### DIFF
--- a/25-minimize.ks
+++ b/25-minimize.ks
@@ -30,7 +30,10 @@ rm -rf /usr/lib/firmware/*wifi* \
   /usr/lib/firmware/dvb* \
   /usr/lib/firmware/{yamaha,korg,liquidio,emu,dsp56k,emi26}
 
-echo " * compressing cracklib dictionary"
+echo " * dropping big and compressing small cracklib dict"
+mv -f /usr/share/cracklib/cracklib_small.hwm /usr/share/cracklib/pw_dict.hwm
+mv -f /usr/share/cracklib/cracklib_small.pwd /usr/share/cracklib/pw_dict.pwd
+mv -f /usr/share/cracklib/cracklib_small.pwi /usr/share/cracklib/pw_dict.pwi
 gzip -9 /usr/share/cracklib/pw_dict.pwd
 
 # remove things only needed during the build process


### PR DESCRIPTION
This will save about 9 MB of compressed data. When testing this, try to log in and change root password using `passwd` command to make sure PAM cracklib works just fine.