### PR TITLE
Fixes #23845 - drop more drivers

### DIFF
--- a/25-minimize.ks
+++ b/25-minimize.ks
@@ -12,21 +12,23 @@ systemctl disable sshd.service
 
 # This seems to cause 'reboot' resulting in a shutdown on certain platforms
 # See https://tickets.puppetlabs.com/browse/RAZOR-100
-echo " * disable the mei_me module"
-mkdir -p /etc/modprobe.d
-cat > /etc/modprobe.d/mei.conf <<EOMEI
-blacklist mei_me
-install mei_me /bin/true
-blacklist mei
-install mei /bin/true
-EOMEI
+echo " * remove intel mei modules"
+rm -rf /lib/modules/*/kernel/drivers/misc/mei
 
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1335830
-echo " * remove KMS DRM video drivers to prevent kexec isues"
-rm -rf /lib/modules/*/kernel/drivers/gpu/drm /lib/firmware/{amdgpu,radeon}
+echo " * remove some video drivers to prevent kexec isues"
+rm -rf /lib/modules/*/kernel/drivers/gpu/drm \
+  /lib/modules/*/kernel/drivers/video/fbdev \
+  /lib/firmware/{amdgpu,radeon}
 
-echo " * remove unused drivers"
+echo " * remove unused drivers (sound, media, nls)"
 rm -rf /lib/modules/*/kernel/{sound,drivers/media,fs/nls}
+
+echo " * remove unused firmware (sound, wifi)"
+rm -rf /usr/lib/firmware/*wifi* \
+  /usr/lib/firmware/v4l* \
+  /usr/lib/firmware/dvb* \
+  /usr/lib/firmware/{yamaha,korg,liquidio,emu,dsp56k,emi26}
 
 echo " * compressing cracklib dictionary"
 gzip -9 /usr/share/cracklib/pw_dict.pwd

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -144,7 +144,14 @@ def main_loop
   end
 
   Newt::Screen.new
-  Newt::Screen.push_helpline(_("Foreman Discovery Image") + " v#{fdi_version} (#{fdi_release})")
+  mode = if File.exists?("/sys/firmware/efi/")
+           "UEFI"
+         else
+           "BIOS"
+         end
+  driver = `cat /proc/fb`.strip.tr("\n", ' ')
+  driver = "NO-FB" if driver.empty?
+  Newt::Screen.push_helpline(_("Foreman Discovery Image") + " v#{fdi_version} (#{fdi_release}) #{RUBY_PLATFORM} #{mode} #{driver}")
 
   if cmdline('BOOTIF')
     # Booted via PXE


### PR DESCRIPTION
This drops more unnecessary video drivers which can cause KMS/Kexec issues. Also it shows if system was booted in BIOS or UEFI in the status line.