### PR TITLE
Fixes #24378 - added Hyper-V drivers

### DIFF
--- a/10-header.ks
+++ b/10-header.ks
@@ -9,6 +9,6 @@ selinux --permissive
 bootloader --timeout=1 --append="acpi=force"
 # root password is "redhat" but account is locked - use fdi.rootpw kernel option
 rootpw --iscrypted $1$_redhat_$i3.3Eg7ko/Peu/7Q/1.wJ/
-part / --size 1200 --fstype ext4 --ondisk sda
+part / --size 1300 --fstype ext4 --ondisk sda
 
 services --disabled=network,sshd --enabled=NetworkManager

--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -137,4 +137,9 @@ cat > /etc/udev/rules.d/82-enable-lldp.rules <<'UDEV'
 ACTION=="add", SUBSYSTEM=="net", NAME!="lo", TAG+="systemd", ENV{SYSTEMD_WANTS}="enable-lldp@%k.service"
 UDEV
 
+echo " * inserting missing initramdisk drivers"
+kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
+ramfsfile="/boot/initramfs-$kversion.img"
+/sbin/dracut --force --add-drivers "mptbase mptscsih mptspi hv_storvsc hid_hyperv hv_netvsc hv_vmbus" $ramfsfile $kversion
+
 %end


### PR DESCRIPTION
Don't test this with real Hyper-V hypervisor if you don't have any. Just build new image and then verify that before and after the patch the drivers are now present:

    lsinitrd /home/libvirt/fdi-image/initrd0.img | grep hyper