### PR TITLE
Copy remastered grub.cfg into efiboot.img to fix UEFI discovery

### DIFF
--- a/aux/remaster/discovery-remaster
+++ b/aux/remaster/discovery-remaster
@@ -83,6 +83,12 @@ menuentry 'Check media' --class fedora --class gnu-linux --class gnu --class os 
 }
 EOGR
 
+TMP_NEW_MNT=$(mktemp -d)
+mount -o loop $TMP_NEW/isolinux/efiboot.img $TMP_NEW_MNT
+cp $TMP_NEW/EFI/BOOT/grub.cfg $TMP_NEW_MNT/EFI/BOOT/grub.cfg
+umount $TMP_NEW_MNT
+rmdir $TMP_NEW_MNT
+
 echo "Building new ISO image..."
 if [ -f "$TMP_NEW/isolinux/efiboot.img" ]; then
   EFI_OPTS="-eltorito-alt-boot -e isolinux/efiboot.img -no-emul-boot"


### PR DESCRIPTION
This should fix remastered images not auto provisioning in EUFI boot environments. 
mkisofs was being called with "-e isolinux/efiboot.img" which contained the EUFI partition and grub.cfg which was not being updated with the kernel command line options when "$TMP_NEW/EFI/BOOT/grub.cfg" was being generated.
This patch will mount the efiboot.img, copy in the newly updated grub.cfg, unmount and unlink the temporary directory.  