### PR TITLE
Fixes #20200 - add promisc mode service + udev rule

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -137,6 +137,11 @@ cat > /etc/udev/rules.d/82-enable-lldp.rules <<'UDEV'
 ACTION=="add", SUBSYSTEM=="net", NAME!="lo", TAG+="systemd", ENV{SYSTEMD_WANTS}="enable-lldp@%k.service"
 UDEV
 
+echo " * enable promiscuous mode on all physical network interfaces"
+cat > /etc/udev/rules.d/83-enable-promiscuous-mode.rules <<'UDEV'
+ACTION=="add", SUBSYSTEM=="net", NAME!="lo", TAG+="systemd", ENV{SYSTEMD_WANTS}="enable-promiscuous-mode@%k.service"
+UDEV
+
 echo " * inserting missing initramdisk drivers"
 kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 ramfsfile="/boot/initramfs-$kversion.img"

--- a/root/etc/systemd/system/enable-promiscuous-mode@.service
+++ b/root/etc/systemd/system/enable-promiscuous-mode@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Control promiscuous mode for interface %i
+After=network-online.target
+Wants=network-online.target
+ConditionKernelCommandLine=!fdi.nopromis
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/ip link set promisc on dev %i
+ExecStop=/sbin/ip link set promisc off dev %i
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
some cisco switches will send lldp packets tagged with vlan 1 when the port mode is set to trunk and the native vlan is set to something else than vlan 1. this leads to the case that the switch sends those lldp packets but the server's nic will trash the packet as it is tagged with vlan 1 and this is out of interest for the nic. there are 2 possible solutions for this:

1. set the port mode to acccess with the corresponding correct vlan id. in this case the switch will not tag lldp packets with vlan id 1 and the server receives it properly.
2. set all interfaces in the foreman discovery image to promiscuous mode.

since we can obviously can not assume that every switch sends those packages with a correct vlan tag and we can not assume that ports are always in access mode it is the most easiest way to just set all interfaces in foreman discovery image to pomisc mode. 

this PR will add a corresponding systemd service and a udev rule that triggers the sysemd service to set the mode on the interface.

i have build a an image with this change and the test after login via ssh shows that it was successful:

```
[root@fdi ~]# ifconfig
eno49: flags=4419<UP,BROADCAST,RUNNING,PROMISC,MULTICAST>  mtu 1500
        inet 10.2.247.197  netmask 255.255.0.0  broadcast 10.2.255.255
        inet6 fe80::4adf:37ff:fe44:81f4  prefixlen 64  scopeid 0x20<link>
        ether 48:df:37:44:81:f4  txqueuelen 1000  (Ethernet)
        RX packets 30722  bytes 16844329 (16.0 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 30211  bytes 1414734 (1.3 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

eno50: flags=4419<UP,BROADCAST,RUNNING,PROMISC,MULTICAST>  mtu 1500
        ether 48:df:37:44:81:f5  txqueuelen 1000  (Ethernet)
        RX packets 580  bytes 62694 (61.2 KiB)
        RX errors 0  dropped 14  overruns 0  frame 0
        TX packets 19  bytes 1387 (1.3 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

lo: flags=329<UP,LOOPBACK,RUNNING,PROMISC>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
