### PR TITLE
Fixes #14922 - adds efi facts to determine BIOS/EFI

### DIFF
--- a/root/usr/share/fdi/facts/efi.rb
+++ b/root/usr/share/fdi/facts/efi.rb
@@ -1,0 +1,21 @@
+# (c) Pat Riehecky 2016, Apache Public License 2.0
+#
+# Fact: efi
+#
+# Purpose: Set 'true' if system is booted into EFI
+#
+# Resolution:
+#   if /sys/firmware/efi exists this is true, else false
+#
+# Notes:
+#   The result is boolean
+#
+require 'facter'
+
+Facter.add(:efi) do
+  confine :kernel => "Linux"
+
+  setcode do
+    File.directory?('/sys/firmware/efi')
+  end
+end


### PR DESCRIPTION
This enables Foreman users to create rules for different hostgroups with different PXE loaders.