### PR TITLE
Added more options to customize bonding interface (device, bootproto).

### DIFF
--- a/root/usr/share/fdi/script-helpers.sh
+++ b/root/usr/share/fdi/script-helpers.sh
@@ -30,13 +30,13 @@ hwaddr() {
 }
 
 cfg_eth() {
-  NAME=${1:-eth0}
-  cat >/etc/sysconfig/network-scripts/ifcfg-$NAME <<EOF
+  DEVICE=${1:-eth0}
+  NAME=${2:-$DEVICE}
+  cat >/etc/sysconfig/network-scripts/ifcfg-$DEVICE <<EOF
 TYPE=Ethernet
-NAME=$DEV
-DEVICE=$DEV
+NAME=$NAME
+DEVICE=$DEVICE
 ONBOOT=yes
-$2
 $3
 $4
 $5
@@ -48,11 +48,11 @@ EOF
 }
 
 cfg_bond() {
-  NAME=${1:-bond0}
+  DEVICE=${1:-bond0}
   OPTS=${2:-miimon=100 mode=balance-rr}
   BOOTPROTO=${3:-dhcp}
-  DEVICE=${4:-$NAME}
-  cat >/etc/sysconfig/network-scripts/ifcfg-$NAME <<EOF
+  NAME=${4:-$DEVICE}
+  cat >/etc/sysconfig/network-scripts/ifcfg-$DEVICE <<EOF
 TYPE=Bond
 ONBOOT=yes
 DEVICE=$DEVICE

--- a/root/usr/share/fdi/script-helpers.sh
+++ b/root/usr/share/fdi/script-helpers.sh
@@ -50,18 +50,18 @@ EOF
 cfg_bond() {
   NAME=${1:-bond0}
   OPTS=${2:-miimon=100 mode=balance-rr}
+  BOOTPROTO=${3:-dhcp}
+  DEVICE=${4:-$NAME}
   cat >/etc/sysconfig/network-scripts/ifcfg-$NAME <<EOF
 TYPE=Bond
 ONBOOT=yes
-DEVICE=$NAME
+DEVICE=$DEVICE
 BONDING_MASTER=yes
 BONDING_OPTS="$OPTS"
-BOOTPROTO=dhcp
+BOOTPROTO=$BOOTPROTO
 DEFROUTE=yes
 IPV6INIT=no
 NAME=$NAME
-$3
-$4
 $5
 $6
 $7


### PR DESCRIPTION
Use case:
- no provisioning network or DHCP available (PXE not an option)
- using a customized boot image with static network config (iPXE boot image) from where FDI is booted with all fdi.pxXXX  required parameters and custom facts 
- fdi.script option is used

Requirement:
- cfg_bond needs to configure static address and allow to use for example a bonding interface with `DEVICE=bond0` and `NAME=primary`, given that an NM connection named `primary` is a requirement for `generate-proxy-cert` to be successful.