### PR TITLE
Minimize image even more

### DIFF
--- a/10-header.ks
+++ b/10-header.ks
@@ -9,6 +9,6 @@ selinux --permissive
 bootloader --timeout=1 --append="acpi=force"
 # root password is "redhat" but account is locked - use fdi.rootpw kernel option
 rootpw --iscrypted $1$_redhat_$i3.3Eg7ko/Peu/7Q/1.wJ/
-part / --size 1900 --fstype ext4 --ondisk sda
+part / --size 1600 --fstype ext4 --ondisk sda
 
 services --disabled=network,sshd --enabled=NetworkManager

--- a/20-packages.ks
+++ b/20-packages.ks
@@ -83,19 +83,44 @@ e2fsprogs
 bzip2
 system-storage-manager
 
+# finding duplicite files saves about 1% of the compressed size
+rdfind
+
 ######################
 # Packages to Remove #
 ######################
+#
+# Some ideas from:
+#
+# https://github.com/weldr/lorax/blob/rhel7-branch/share/runtime-cleanup.tmpl
 
 # Red Hat Enteprise Linux subscription tool
 -subscription-manager
 
-# Generic and wireless tools
+# Generic and wireless tools and firmware
 -prelink
 -setserial
 -ed
 -authconfig
 -wireless-tools
+-iwl7260-firmware
+-iwl3160-firmware
+-iwl6000g2b-firmware
+-iwl6000g2a-firmware
+-iwl5000-firmware
+-iwl6050-firmware
+-iwl2030-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl105-firmware
+-iwl1000-firmware
+-iwl6000-firmware
+-iwl100-firmware
+-iwl5150-firmware
+-iwl4965-firmware
+-iwl3945-firmware
+-liquidio-firmware
+-netronome-firmware
 
 # Remove the kbd bits
 -kbd
@@ -105,10 +130,22 @@ system-storage-manager
 -dmraid
 -lvm2
 
+# sound and video
+-alsa-lib
+-alsa-firmware
+-alsa-tools-firmware
+-ivtv-firmware
+
 # selinux toolchain of policycoreutils, libsemanage (libselinux is needed tho)
 -selinux-policy*
 
-# Things it would be nice to loose
+# logos and graphics
+-plymouth
+-centos-logos
 -fedora-logos
 -fedora-release-notes
+
+# other packages
+-postfix
+
 %end


### PR DESCRIPTION
The FDI system is base RHEL7 with a minimum set of packages, because
of slow and unreliable PXE the goal is to keep the image size as small
as possible, therefore some files are completely removed
(documentation, man pages, i18n). When we started with this, the image
size was reasonable (145MB) but then it was only growing. Today it's
415MB, it's growing quite fast. Although we added SCL Ruby for some
Foreman services, that does not justify such growth.

Thus this patch. Overall I was able to bring down the size from 415M to 335M
with these changes. Not bad, I could go even further analyzing one package
after another, but we plan to remove Ruby from the image so I will rather
invest time into this.