### PR TITLE
Removed auditd and rsyslog

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -147,5 +147,9 @@ rdfind
 
 # other packages
 -postfix
+-audit
+-rsyslog
+-authconfig
+-tuned
 
 %end


### PR DESCRIPTION
Few more services saves 3 MB and some memory since logs are in journald anyways and we don't need to keep copies in `/var/log/messages`.