### PR TITLE
Resolve IPv6 foreman.url and don't fail on dualstack

### DIFF
--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -110,6 +110,7 @@ dhcp-send-hostname=$sendhost
 dhcp-timeout=$timeout
 [ipv6]
 method=$ipv6_method
+may-fail=true
 [vlan]
 id=$vlanid
 EONS
@@ -135,6 +136,7 @@ never-default=true
 dhcp-send-hostname=$sendhost
 [ipv6]
 method=$ipv6_method
+may-fail=true
 EONS
   deploy_config $TMP_CFG $script
 else

--- a/root/usr/lib64/ruby/vendor_ruby/discovery.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery.rb
@@ -170,12 +170,12 @@ def upload(uri = discover_server, type = proxy_type, custom_facts = {})
     log_err "Upload#uri must be type of URI"
     return
   end
-  if uri.host.nil? or uri.port.nil?
+  if uri.hostname.nil? or uri.port.nil?
     log_err "Server or proxy URI host or port was not specified, cannot continue"
     return
   end
   log_msg "Registering host at (#{uri})"
-  http = Net::HTTP.new(uri.host, uri.port)
+  http = Net::HTTP.new(uri.hostname, uri.port)
   if uri.scheme == 'https' then
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
+++ b/root/usr/lib64/ruby/vendor_ruby/discovery/menu.rb
@@ -93,7 +93,7 @@ def configure_network static, mac, ip=nil, gw=nil, dns=nil, vlan=nil
   sleep 2
   up_result = command("nmcli -w #{wait} connection up primary", false)
   sleep 2
-  command("nm-online -s -q --timeout=#{wait}")
+  command("nm-online -s -q --timeout=#{wait}", false)
   # wait for IPv4, generate SSL self-signed cert and start proxy
   command("systemctl start foreman-proxy") && up_result
 end


### PR DESCRIPTION
When parsing URL `host` does not handle `[IPv6::]` URL syntax, for that
Ruby has `hostname`. This fixes it.

Also on dualstack FDI was erroring out when IPv6 was not started on IPv4
or dualstacks. This makes it silent, it only goes into system log.