### PR TITLE
Fixes #31481 - fix nm configuration IPv6 ignore and remove facter2

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -21,8 +21,7 @@ elfutils-libs
 tar
 gzip
 
-# Facter (both CLI and for smart-proxy image plugin)
-facter
+# Facter
 tfm-rubygem-facter
 ethtool
 net-tools

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ Some extra facts are reported in addition to the standard ones reported by
 Facter:
 
 ```
-FACTERLIB=/usr/share/fdi/facts/ facter | grep discovery
+source /etc/default/discovery
+export FACTERLIB
+facter | grep discovery
 discovery_bootif => 52:54:00:94:9e:52
 discovery_bootip => 192.168.122.51
 ```

--- a/root/usr/bin/discovery-debug
+++ b/root/usr/bin/discovery-debug
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /etc/default/discovery
+export FACTERLIB
 
 echo "* LOOPBACK ISO IMAGE CHECK"
 checkisomd5 /dev/loop0
@@ -39,7 +40,7 @@ echo "* IMAGE VERSION"
 cat /usr/share/fdi/VERSION /usr/share/fdi/RELEASE
 
 echo "* FACTER *"
-FACTERLIB=/usr/share/fdi/facts/ facter --json
+facter --json
 
 echo "* JOURNAL (last 500 lines) *"
 journalctl -n300 -ocat

--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -58,7 +58,7 @@ gateway=$gw
 dns=$dns;
 dhcp-send-hostname=$sendhost
 [ipv6]
-method=disabled
+method=ignore
 [vlan]
 id=$vlanid
 EONS


### PR DESCRIPTION
A typo in the config file, IPv4 requires "disabled" but IPv6 requires "ignore". In Fedora man pages this is both "disabled", it recently changed upstream likely.

The second patch finalizes removing facter 2. FDI is now fully on SCL Ruby and Facter 4.