### PR TITLE
Resolve nil exception for ethtool custom fact

### DIFF
--- a/root/usr/share/fdi/facts/ethtool.rb
+++ b/root/usr/share/fdi/facts/ethtool.rb
@@ -9,7 +9,11 @@
 require 'facter'
 
 Facter.add(:ethtool, :timeout => 10) do
-  confine :kernel => "Linux"
+  confine kernel: "Linux"
+
+  confine :networking do |value|
+    value && value['interfaces']
+  end
 
   confine do
     Facter::Core::Execution.which('ethtool') != nil


### PR DESCRIPTION
Just a quick fix - when DNS is incorrect, facter 4 for some reason does not resolve "networking" at all and it returns `nil`.