### PR TITLE
Dockerfile.centos: install tools needed to build the live CD

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,0 +1,9 @@
+FROM centos:7
+
+RUN yum install -y pykickstart isomd5sum syslinux grub2-efi shim grub2-efi-x64 grub2-efi-x64-cdboot shim-x64 git libguestfs-tools dd mkisofs isohybrid implantisomd5
+RUN rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
+RUN yum install -y https://www.elrepo.org/elrepo-release-7.el7.elrepo.noarch.rpm
+RUN yum install -y livecd-tools
+RUN git clone https://github.com/theforeman/foreman-discovery-image.git
+RUN (cd foreman-discovery-image; ./build-livecd fdi-centos7.ks)
+#RUN (cd foreman-discovery-image; ./build-livecd-root)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,26 @@ To build the image (make sure you have at least 3 GB free space in /tmp):
 $ sudo ./build-livecd-root
 ```
 
-Copy the resulting tarball to the TFTP boot directory:
+It's also possible to build the image inside of a docker container.  This is
+especially useful if you don't have immediate access to a Fedora or CentOS 7
+system.  You can build the docker container using the Dockerfile in this repo:
+
+```
+docker build -t fdi - < Dockerfile.centos
+```
+
+You then need only to run the final build-livecd-root command inside the docker
+container:
+
+```
+$ docker run --privileged=true -v $PWD:/home -tie /bin/bash fdi
+# cd foreman-discovery-image
+# ./build-livecd-root
+
+```
+
+Regardless of how you built the image (docker or not), the next step is to copy
+the resulting tarball to the TFTP boot directory:
 
 ```
 $ tar xvf fdi-image-*.tar -C /var/lib/tftpboot/boot


### PR DESCRIPTION
Create a Docker image that can run build-livecd-root.  This allows
building the image on foreign (non Fedora/CentOS) systems