### PR TITLE
Minimize image size after EL8 upgrade

### DIFF
--- a/build-livecd-root
+++ b/build-livecd-root
@@ -56,6 +56,10 @@ livemedia-creator --ks fdi-image.ks \
        	--dracut-arg="--omit plymouth" \
         --dracut-arg="--add livenet dmsquash-live convertfs pollcdrom qemu qemu-net" \
         --dracut-arg="--add-drivers mptbase mptscsih mptspi hv_storvsc hid_hyperv hv_netvsc hv_vmbus" \
+	--compression xz \
+	--compress-arg="-b 1M" \
+	--compress-arg="-Xdict-size 1M" \
+	--compress-arg="-no-recovery" \
 	--tmp "$tmpdir"
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
So FDI grew to 480MB:

```
-rw-r--r--. 1 lzap lzap 483M 23. pro 16.06 fdi-3.8.0-d737a06.iso
```

This PR should improve this. WIP, do not merge.