### PR TITLE
Module is required now for rubygem-facter to install

### DIFF
--- a/00-repos-centos8.ks
+++ b/00-repos-centos8.ks
@@ -6,3 +6,5 @@ repo --name="AppStream" --baseurl=http://mirror.centos.org/centos/8-stream/AppSt
 repo --name="foreman-el8" --baseurl=http://yum.theforeman.org/releases/nightly/el8/$basearch/
 repo --name="foreman-plugins-el8" --baseurl=http://yum.theforeman.org/plugins/nightly/el8/$basearch/
 module --name=ruby --stream=2.7
+module --name=postgresql --stream=12
+module --name=foreman --stream=el8


### PR DESCRIPTION
This fixed the problem reported in

https://community.theforeman.org/t/unable-to-build-and-or-remaster-fdi-4-0-3/28678/4

Scratchbuild: https://ci.theforeman.org/job/foreman-discovery-image-release/50/