### PR TITLE
 Add support for building discovery image using other distros rocky8/alma8 in addition to centos stream 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /00-repos-rhel*.ks
 /fdi-rhel*.ks
 /build-livecd-root.conf.sh
+/install.iso

--- a/00-repos-alma8.ks
+++ b/00-repos-alma8.ks
@@ -1,0 +1,6 @@
+# Alma 8 Repos
+url --url http://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/
+repo --name="AppStream" --baseurl=http://repo.almalinux.org/almalinux/8/AppStream/x86_64/os/
+repo --name="foreman-el8" --baseurl=http://yum.theforeman.org/releases/nightly/el8/$basearch/
+repo --name="foreman-plugins-el8" --baseurl=http://yum.theforeman.org/plugins/nightly/el8/$basearch/
+module --name=ruby --stream=2.7

--- a/00-repos-centos8.ks
+++ b/00-repos-centos8.ks
@@ -1,6 +1,3 @@
-# mirrorlist.centos.org not available on the CentOS CI
-#url --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=baseos
-#repo --name="AppStream" --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=appstream
 url --url http://mirror.centos.org/centos/8-stream/BaseOS/$basearch/os/
 repo --name="AppStream" --baseurl=http://mirror.centos.org/centos/8-stream/AppStream/$basearch/os/
 repo --name="foreman-el8" --baseurl=http://yum.theforeman.org/releases/nightly/el8/$basearch/

--- a/00-repos-rocky8.ks
+++ b/00-repos-rocky8.ks
@@ -1,0 +1,6 @@
+# Rocky 8 Repos
+url --url https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/
+repo --name="AppStream" --baseurl=https://download.rockylinux.org/pub/rocky/8/AppStream/x86_64/os/
+repo --name="foreman-el8" --baseurl=http://yum.theforeman.org/releases/nightly/el8/$basearch/
+repo --name="foreman-plugins-el8" --baseurl=http://yum.theforeman.org/plugins/nightly/el8/$basearch/
+module --name=ruby --stream=2.7

--- a/20-packages.ks
+++ b/20-packages.ks
@@ -17,7 +17,6 @@ isomd5sum
 # required by lorax
 dracut-live
 # required by bootloader
-centos-logos
 memtest86+
 biosdevname
 vim-minimal

--- a/20-packages.ks
+++ b/20-packages.ks
@@ -78,6 +78,7 @@ mdadm
 xfsprogs
 e2fsprogs
 bzip2
+tcpdump
 
 ######################
 # Packages to Remove #

--- a/build-livecd
+++ b/build-livecd
@@ -47,4 +47,30 @@ ksflatten -v RHEL8 -c "$1" -o $KS_TARGET
 sed "s|yum.theforeman.org/nightly|yum.theforeman.org/releases/$FOREMAN_VERSION|" -i $KS_TARGET
 sed "s|yum.theforeman.org/plugins/nightly|yum.theforeman.org/plugins/$FOREMAN_VERSION|" -i $KS_TARGET
 
+
+# set variables based on distro
+case $1 in
+	*rocky8*)
+                DISTRO_INSTALL_NAME="Rocky Linux 8"
+                DISTRO_INSTALL_ISO_URL="https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.5-x86_64-boot.iso"
+		;;
+	*alma8*)
+                DISTRO_INSTALL_NAME="Alama Linux 8"
+                DISTRO_INSTALL_ISO_URL="https://repo.almalinux.org/almalinux/8/isos/x86_64/AlmaLinux-8.6-x86_64-boot.iso"
+		;;
+	*)
+                DISTRO_INSTALL_NAME="Centos 8 Stream"
+                DISTRO_INSTALL_ISO_URL="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/boot.iso"
+		;;
+esac
+if [ -f build-livecd-root.conf.sh ]; then
+	mv build-livecd-root.conf.sh build-livecd-root.conf.sh.PREV
+fi
+cat <<EOF > build-livecd-root.conf.sh
+#
+DISTRO_INSTALL_NAME="${DISTRO_INSTALL_NAME}"
+DISTRO_INSTALL_ISO_URL="${DISTRO_INSTALL_ISO_URL}"
+EOF
+
+
 echo "Now run as root ./build-livecd-root or submit $KS_TARGET into koji"

--- a/build-livecd-root
+++ b/build-livecd-root
@@ -23,6 +23,22 @@ fi
 
 which livemedia-creator ksflatten wget >/dev/null || ( echo "Command(s) missing, install required tools" && exit 2 )
 
+# Use custom setings from config file
+if [ -z ${DISTRO_INSTALL_ISO_URL} ]; then
+	DISTRO_INSTALL_ISO_URL="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/boot.iso"
+fi
+
+if [ -z ${DISTRO_INSTALL_NAME} ]; then
+	DISTRO_INSTALL_NAME="Centos 8 Stream"
+fi
+
+if [ -n ${CUSTOM_LORAX_DIR} ]; then
+	LORAX_TEMPLATES="--lorax-templates ${CUSTOM_LORAX_DIR}"
+else
+	LORAX_TEMPLATES=""
+fi
+
+
 srcdir=$(readlink -f $(dirname $0))
 destdir=${2:-$srcdir}
 kernelcmd=${3:-nomodeset nokaslr}
@@ -39,24 +55,23 @@ if [[ "$buildytype" = virt ]]; then
 	BUILD_OPTS="--iso install.iso"
 	if [ ! -e install.iso ]; then
 		echo "* Downloading netboot installation ISO"
-		wget --quiet -O install.iso http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/boot.iso
+		wget --quiet -O install.iso ${DISTRO_INSTALL_ISO_URL}
 	fi
 else
-	echo "* Using non-virt mode, make sure the host system is CentOS 8 Stream"
+	echo "* Using non-virt mode, make sure the host system is ${DISTRO_INSTALL_NAME}"
 	echo "  (This mode can destroy the host system, only use dedicated VMs!)"
 	BUILD_OPTS="--no-virt"
 fi
 
 echo "* Building ISO (kernel cmdline: $kernelcmd)"
-# https://bugzilla.redhat.com/show_bug.cgi?id=1955836 - dmsquash-live-ntfs
-# https://bugzilla.redhat.com/show_bug.cgi?id=2034601 - product CentOS Linux workaround
+
 livemedia-creator $BUILD_OPTS --ks fdi-image.ks \
 	--make-iso \
 	--nomacboot \
 	--extra-boot-args "$kernelcmd" \
 	--project "FDI" \
 	--releasever "$last_tag/$last_sha" \
-	--anaconda-arg="--product CentOS Linux" \
+	--anaconda-arg="--product ${DISTRO_INSTALL_NAME}" \
 	--dracut-arg="--xz" \
 	--dracut-arg="--no-hostonly" \
 	--dracut-arg="--debug" \
@@ -64,7 +79,9 @@ livemedia-creator $BUILD_OPTS --ks fdi-image.ks \
        	--dracut-arg="--omit plymouth" \
         --dracut-arg="--add livenet dmsquash-live convertfs pollcdrom qemu qemu-net" \
         --dracut-arg="--add-drivers mptbase mptscsih mptspi hv_storvsc hid_hyperv hv_netvsc hv_vmbus" \
-	--tmp "$tmpdir"
+        --ram 2048 \
+        --vcpus 2 \
+	--tmp "$tmpdir" ${LORAX_TEMPLATES}
 
 if [ $? -ne 0 ]; then
 	echo "Error creating livecd, use KEEP_TMPDIR to investigate"

--- a/build-livecd-root
+++ b/build-livecd-root
@@ -32,10 +32,10 @@ if [ -z ${DISTRO_INSTALL_NAME} ]; then
 	DISTRO_INSTALL_NAME="Centos 8 Stream"
 fi
 
-if [ -n ${CUSTOM_LORAX_DIR} ]; then
-	LORAX_TEMPLATES="--lorax-templates ${CUSTOM_LORAX_DIR}"
-else
+if [ -z ${CUSTOM_LORAX_DIR} ]; then
 	LORAX_TEMPLATES=""
+else
+	LORAX_TEMPLATES="--lorax-templates ${CUSTOM_LORAX_DIR}"
 fi
 
 

--- a/fdi-alma8.ks
+++ b/fdi-alma8.ks
@@ -1,0 +1,6 @@
+%include 10-header.ks
+%include 00-repos-centos8.ks
+%include 20-packages.ks
+%include fdi-install.ks
+%include 22-discovery.ks
+%include 25-minimize.ks

--- a/fdi-rocky8.ks
+++ b/fdi-rocky8.ks
@@ -1,0 +1,6 @@
+%include 10-header.ks
+%include 00-repos-rocky8.ks
+%include 20-packages.ks
+%include fdi-install.ks
+%include 22-discovery.ks
+%include 25-minimize.ks


### PR DESCRIPTION
Have tested building the discovery image using rocky8 and alma8.  For those who want to use a distro closer to RHEL.  This change makes a few things variablized and allows the user to simply do any of the following:

./build-livecd fdi-alma8.ks
./build-livecd fdi-centos8.ks
./build-livecd fdi-rocky8.ks