### PR TITLE
fix downloading of zip files broken by firewall rules

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -30,6 +30,12 @@ UDEV
 echo " * configuring TFTP firewall modules"
 echo -e "ip_conntrack_tftp\nnf_conntrack_netbios_ns" > /etc/modules-load.d/tftp-firewall.conf
 
+# https://blog.thewatertower.org/2019/05/01/tftp-part-2-the-tftp-client-requires-a-firewalld-as-well/
+firewall-offline-cmd --new-policy hostTftpTraffic
+firewall-offline-cmd --policy hostTftpTraffic --add-ingress-zone HOST
+firewall-offline-cmd --policy hostTftpTraffic --add-egress-zone ANY
+firewall-offline-cmd --policy hostTftpTraffic --add-service tftp
+
 echo " * enabling NetworkManager system services (needed for RHEL 7.0)"
 systemctl enable NetworkManager.service
 systemctl enable NetworkManager-dispatcher.service


### PR DESCRIPTION
nftables rules in the foreman discovery image allow egress tftp requests but block ingress reply traffic.  The result is that `curl` will eventually fail with an exit code of 28, making it impossible to provide a zip archive with additional facts. E.g.:

```
[root@foreman tftpboot]# tcpdump -i eth0 -vvv -A host 10.10.10.62
tcpdump: listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
20:57:33.477443 IP (tos 0x0, ttl 63, id 39021, offset 0, flags [DF], proto UDP (17), length 85)
    10.10.10.62.46600 > foreman.example.com.tftp: [udp sum ok]  57 RRQ "boot/udev_fact.zip" octet tsize 0 blksize 512 timeout 6
E..U.m@.?.d....>...P...E.AC...boot/udev_fact.zip.octet.tsize.0.blksize.512.timeout.6.
20:57:33.481949 IP (tos 0x0, ttl 64, id 59917, offset 0, flags [none], proto UDP (17), length 62)
    foreman.example.com.47368 > 10.10.10.62.46600: [bad udp cksum 0x3ec3 -> 0xa609!] UDP, length 34
E..>....@.R....P...>.....*>...tsize.921.blksize.512.timeout.6.
20:57:33.482445 IP (tos 0xc0, ttl 63, id 21696, offset 0, flags [none], proto ICMP (1), length 90)
    10.10.10.62 > foreman.example.com: ICMP host 10.10.10.62 unreachable - admin prohibited filter, length 70
	IP (tos 0x0, ttl 63, id 59917, offset 0, flags [none], proto UDP (17), length 62)
    foreman.example.com.47368 > 10.10.10.62.46600: [udp sum ok] UDP, length 34
E..ZT...?......>...P..;.....E..>....?.S....P...>.....*.	..tsize.921.blksize.512.timeout.6.
```

An image built with the modifications in this PR has been tested as allow zip archive downloads to function as described in the manual.