### PR TITLE
disable synced folders

### DIFF
--- a/aux/vagrant-build/Vagrantfile
+++ b/aux/vagrant-build/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "fdi-builder", primary: true do |machine|
     machine.vm.hostname = "fdi-builder-vm"
     machine.vm.provision :shell, :path => 'build_image.sh', :args => SHELLARGS
+    machine.vm.synced_folder ".", "/vagrant", disabled: true
 
     config.vm.provider :libvirt do |domain, cfg|
       cfg.vm.box = 'centos/stream8'


### PR DESCRIPTION
rsync is currently broken in CentOS 8 Stream, but we don't even need it to be working as we do a fresh git clone inside the VM anyways