### PR TITLE
fix: add ipmitool as dependency

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -37,6 +37,7 @@ wget
 passwd
 sudo
 OpenIPMI
+ipmitool
 openssl
 elfutils-libs
 


### PR DESCRIPTION
It's used in discovery-facts.rb, and not installed without this change