### PR TITLE
Disable systemd-journal-flush.service

### DIFF
--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -154,6 +154,9 @@ cat > /etc/udev/rules.d/83-enable-promiscuous-mode.rules <<'UDEV'
 ACTION=="add", SUBSYSTEM=="net", NAME!="lo", TAG+="systemd", ENV{SYSTEMD_WANTS}="enable-promiscuous-mode@%k.service"
 UDEV
 
+echo " * disable flushing log data"
+rm /usr/lib/systemd/system/sysinit.target.wants/systemd-journal-flush.service
+
 # extra modules for livecd-creator/livemedia-creator
 echo 'add_drivers+="mptbase mptscsih mptspi hv_storvsc hid_hyperv hv_netvsc hv_vmbus"' > /etc/dracut.conf.d/99-discovery.conf
 

--- a/22-discovery.ks
+++ b/22-discovery.ks
@@ -155,7 +155,7 @@ ACTION=="add", SUBSYSTEM=="net", NAME!="lo", TAG+="systemd", ENV{SYSTEMD_WANTS}=
 UDEV
 
 echo " * disable flushing log data"
-rm /usr/lib/systemd/system/sysinit.target.wants/systemd-journal-flush.service
+systemctl mask systemd-journal-flush.service
 
 # extra modules for livecd-creator/livemedia-creator
 echo 'add_drivers+="mptbase mptscsih mptspi hv_storvsc hid_hyperv hv_netvsc hv_vmbus"' > /etc/dracut.conf.d/99-discovery.conf


### PR DESCRIPTION
This service tries to store volatile log data to persistent storage. As we don't have any persistant storage, it timeouts after 90s. We do not need this service.

Bug report: https://projects.theforeman.org/issues/36235