### PR TITLE
Add tcpdump to 20-packages.ks

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -79,6 +79,7 @@ mdadm
 xfsprogs
 e2fsprogs
 bzip2
+tcpdump
 
 ######################
 # Packages to Remove #


### PR DESCRIPTION
In my experience building my own discovery images, having tcpdump on the discovery image is extremely valuable to diagnose discovery problems to see if a discovered system is connected to correct network, if there are router, or firewall issues etc.