### PR TITLE
VLAN id entered by users on discovery-menu interface page never used properly

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -79,6 +79,7 @@ mdadm
 xfsprogs
 e2fsprogs
 bzip2
+tcpdump
 
 ######################
 # Packages to Remove #

--- a/root/usr/bin/nm-configure
+++ b/root/usr/bin/nm-configure
@@ -42,7 +42,7 @@ if [[ "$1" == "primary-static" ]]; then
   vlanid=${6:-$KCL_FDI_VLAN_PRIMARY}
   if [[ "$vlanid" != "" ]]; then
     ctype="vlan"
-    vlan_section="[vlan]\nid=$vlanid"
+    vlan_section="[vlan]"$'\n'"id=$vlanid"
   else
     vlan_section=""
   fi
@@ -74,7 +74,7 @@ elif [[ "$1" == "primary-static6" ]]; then
   vlanid=${6:-$KCL_FDI_VLAN_PRIMARY}
   if [[ "$vlanid" != "" ]]; then
     ctype="vlan"
-    vlan_section="[vlan]\nid=$vlanid"
+    vlan_section="[vlan]"$'\n'"id=$vlanid"
   else
     vlan_section=""
   fi
@@ -103,7 +103,7 @@ elif [[ "$1" == "primary" ]]; then
   vlanid=${3:-$KCL_FDI_VLAN_PRIMARY}
   if [[ "$vlanid" != "" ]]; then
     ctype="vlan"
-    vlan_section="[vlan]\nid=$vlanid"
+    vlan_section="[vlan]"$'\n'"id=$vlanid"
   else
     vlan_section=""
   fi


### PR DESCRIPTION
The ability for users to enter a VLAN in the discovery interface menu is currently broken.  If the user enters it, the value never gets used because the Network Manager config file is not proper format for the data.

The culprit is the nm-configure script trying to improperly insert a newline in a bash variable assignment.

This makes the /etc/NetworkManager/system-connections files look improperly like this:
[vlan]\nid=123

Instead of:
[vlan]
id=123

With this fix, adding the newline correctly, NetworkManager will now use the vlan id entered by the user on the discovery-menu interface selection page.
