### PR TITLE
Revert the removal of network drivers and packages

### DIFF
--- a/20-packages.ks
+++ b/20-packages.ks
@@ -97,6 +97,23 @@ tcpdump
 -setserial
 -ed
 -authconfig
+-wireless-tools
+-iwl7260-firmware
+-iwl3160-firmware
+-iwl6000g2b-firmware
+-iwl6000g2a-firmware
+-iwl5000-firmware
+-iwl6050-firmware
+-iwl2030-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl105-firmware
+-iwl1000-firmware
+-iwl6000-firmware
+-iwl100-firmware
+-iwl5150-firmware
+-iwl4965-firmware
+-iwl3945-firmware
 -liquidio-firmware
 -netronome-firmware
 

--- a/25-minimize.ks
+++ b/25-minimize.ks
@@ -34,9 +34,11 @@ rm -rf /lib/modules/*/kernel/sound \
   /lib/modules/*/kernel/fs/{nls,ocfs2,ceph,nfsd,ubifs,nilfs2}
 
 echo " * remove unused firmware (sound, wifi)"
-rm /usr/lib/firmware/v4l* \
+rm -rf /usr/lib/firmware/*wifi* \
+  /usr/lib/firmware/v4l* \
   /usr/lib/firmware/dvb* \
-  /usr/lib/firmware/{yamaha,korg,liquidio,emu,dsp56k,emi26}
+  /usr/lib/firmware/{yamaha,korg,liquidio,emu,dsp56k,emi26} \
+  /usr/lib/firmware/{ath9k,ath10k}
 
 echo " * dropping big and compressing small cracklib dict"
 mv -f /usr/share/cracklib/cracklib_small.hwm /usr/share/cracklib/pw_dict.hwm


### PR DESCRIPTION
The image size after adding the drivers is causing an error when loading large (500MB) initrd on UEFI. See https://issues.redhat.com/browse/RHEL-4389

refs d33ed2a79dbc19d2d0a93aa307e099b1204243bc
refs 082b9b5a71403885c0accaed0c2d90674a15e185