### PR TITLE
Fixes #36488 : Formatting fix for contribution URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,10 @@ aux/livecd-iso-to-pxeboot fdi-XYZ.iso
 Contributing
 ------------
 
-Please follow our (generic contributing guidelines for
-Foreman)[http://theforeman.org/contribute.html#SubmitPatches]. Make sure
-you create (an
-issue)[http://projects.theforeman.org/projects/discovery/issues/new] and
+Please follow our [generic contributing guidelines for
+Foreman](http://theforeman.org/contribute.html#SubmitPatches). Make sure
+you create [an
+issue](http://projects.theforeman.org/projects/discovery/issues/new) and
 select "Image" Category.
 
 vim:tw=75


### PR DESCRIPTION
Minor markdown formatting fix in the [**Contributing**](https://github.com/theforeman/foreman-discovery-image/blob/master/README.md#contributing) section as requested in https://projects.theforeman.org/issues/36488