### PR TITLE
Fix repo URLs

### DIFF
--- a/00-repos-centos8.ks
+++ b/00-repos-centos8.ks
@@ -1,8 +1,5 @@
-# mirrorlist.centos.org not available on the CentOS CI
-#url --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=baseos
-#repo --name="AppStream" --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=appstream
-url --url http://mirror.centos.org/centos/8-stream/BaseOS/$basearch/os/
-repo --name="AppStream" --baseurl=http://mirror.centos.org/centos/8-stream/AppStream/$basearch/os/
+url --url http://vault.centos.org/centos/8-stream/BaseOS/$basearch/os/
+repo --name="AppStream" --baseurl=http://vault.centos.org/centos/8-stream/AppStream/$basearch/os/
 repo --name="foreman-el8" --baseurl=http://yum.theforeman.org/releases/nightly/el8/$basearch/
 repo --name="foreman-plugins-el8" --baseurl=http://yum.theforeman.org/plugins/nightly/el8/$basearch/
 module --name=ruby --stream=2.7


### PR DESCRIPTION
The CentOS Stream repositories are no longer available at the current URLs since the CentOS Stream 8 end of builds was May 31, 2024; see [CentOS download page](https://www.centos.org/download/). However, a snapshot of the old repo, without updates, is available at https://vault.centos.org/.
Comment from vault.centos.org:
```
This is _NOT_ an updated tree for installing CentOS Linux : It is a snapshot of the older trees that have been removed from the main CentOS servers as new point releases are released.
This is provided for reference and to provide access to older archived versions, and we do not put security updates into the trees on this server.
Please see http://www.centos.org/download for active versions of CentOS Linux
```