### PR TITLE
Vagrant build on CentOS Stream 9

### DIFF
--- a/aux/vagrant-build/Vagrantfile
+++ b/aux/vagrant-build/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
     machine.vm.synced_folder ".", "/vagrant", disabled: true
 
     config.vm.provider :libvirt do |domain, cfg|
-      cfg.vm.box = 'centos/stream8'
+      cfg.vm.box = 'centos/stream9'
       domain.memory = 7990
       domain.cpus = 2
       domain.nested = true

--- a/aux/vagrant-build/build_image.sh
+++ b/aux/vagrant-build/build_image.sh
@@ -17,18 +17,15 @@ sudo setenforce 0
 # Building in mock did not work at all, therefore building directly on the host
 # VM is the approach.
 
-sudo dnf -y install pykickstart git wget lorax anaconda patch
+sudo dnf -y install pykickstart git wget lorax anaconda
 
 [ -d $NAME ] || git clone https://github.com/$repoowner/$NAME.git -b $branch
 pushd $NAME
 git pull
 
-# required only for CentOS 8 Stream (RHEL works fine)
-sudo patch -p1 -d / < anaconda-rhsm-BZ2034601.patch
-
 version=$(git describe --abbrev=0 --tags)
 
-./build-kickstart fdi-centos8.ks $proxy_repo && sudo ./build-livecd-root "$version" . "$KERNEL_CMDLINE" novirt
+./build-kickstart fdi-stream9.ks $proxy_repo && sudo ./build-livecd-root "$version" . "$KERNEL_CMDLINE" novirt
 
 find .
 popd


### PR DESCRIPTION
How to run
```
cd aux/vagrant-build
vagrant up fdi-builder
```

Verify:
```
vagrant ssh fdi-builder
cd foreman-discovery-image
image is present in the directory
```