### PR TITLE
Fixes #36433 - Add NetworkManager config to support dracut-loaded rootfs

### DIFF
--- a/root/etc/NetworkManager/conf.d/00-ignore-initrd.conf
+++ b/root/etc/NetworkManager/conf.d/00-ignore-initrd.conf
@@ -1,0 +1,3 @@
+[device]
+keep-configuration=no
+allowed-connections=except:origin:nm-initrd-generator


### PR DESCRIPTION
When loading the rootfs via dracut's live kernel parameter (as described in the the README), NetworkManager will pick this configured interface up and name it something like "Wired Connection". This means that the various pieces of code that rely on the primary connection profile in NM being named "primary" will fail, as that profile cannot be activated since it conflicts with the autogenerated one. The included NetworkManager config file will ignore connections that come from NetworkManager's initrd generator, meaning it will initialize the connection anew after the rootfs is already mounted.